### PR TITLE
Only test mkl library with --with-libmkl

### DIFF
--- a/unix/configure.ac
+++ b/unix/configure.ac
@@ -336,11 +336,13 @@ AC_DEFINE([USE_OFFICIAL_BOOST], [], [Use the official Boost libraries.])
 
 # Intel Math Kernel library
 AS_IF([test x"$with_libmkl" != x"no"], [
-pov_save_ldflags="$LDFLAGS"
-LDFLAGS="-L$with_libmkl $LDFLAGS"
-AC_CHECK_LIB([mkl], [sin]) 
-test x"ac_cv_lib_mkl_sin" = x"no" && LDFLAGS="$pov_save_ldflags" && \
+  pov_save_ldflags="$LDFLAGS"
+  AS_IF([test x"$with_libmkl" != x"yes"], [
+    LDFLAGS="-L$with_libmkl $LDFLAGS"
+  ])
+  AC_CHECK_LIB([mkl], [sin], [], [
 	AC_MSG_ERROR([Cannot find working mkl library])
+  ])
 ])
 
 # libm


### PR DESCRIPTION
If we do not make the test conditionally and use --without-libmkl during
configure, we end up with -Lno in LDFLAGS.

Signed-off-by: Justin Lecher jlec@gentoo.org
