### PR TITLE
Trivial update to README.md

### DIFF
--- a/unix/README.md
+++ b/unix/README.md
@@ -11,6 +11,20 @@ releasing a source package.
 NB if you have improvements to the below instructions, please add a comment
 to issue #1, or (if you are working in a branch) send us a pull request.
 
+Dependencies
+============
+
+By default POV-Ray will attempt to build using system-supplied libraries for
+boost, zlib, libpng, libjpeg, libtiff, and openexr. We recommend you have the
+following packages pre-installed: 
+
+    libboost-dev
+    zlib1g-dev
+    libpng12-dev
+    libjpeg8-dev
+    libtiff5-dev
+    libopenexr-dev
+    
 Generating configure and building the code
 ==========================================
 
@@ -42,17 +56,3 @@ of the user (or root) who is doing the installation.
 
 Please see [unix/install.txt](install.txt) for more details about available
 configuration options etc.
-
-Dependencies
-============
-
-By default POV-Ray will attempt to build using system-supplied libraries for
-boost, zlib, libpng, libjpeg, libtiff, and openexr. We recommend you have the
-following packages pre-installed: 
-
-    libboost-dev
-    zlib1g-dev
-    libpng12-dev
-    libjpeg8-dev
-    libtiff5-dev
-    libopenexr-dev


### PR DESCRIPTION
It helps having the dependencies listed before the actual install instructions, so that one doesn't have to have the configure step fail multiple times before hitting each dependency.