### PR TITLE
Update vector.h

### DIFF
--- a/source/core/math/vector.h
+++ b/source/core/math/vector.h
@@ -314,8 +314,8 @@ class GenericVector2d
         }
         inline bool IsNearNull(T epsilon) const
         {
-            return (abs(vect[X]) < epsilon) &&
-                   (abs(vect[Y]) < epsilon);
+            return (fabs(vect[X]) < epsilon) &&
+                   (fabs(vect[Y]) < epsilon);
         }
         inline GenericVector2d normalized() const
         {
@@ -540,9 +540,9 @@ class GenericVector3d
         }
         inline bool IsNearNull(T epsilon) const
         {
-            return (abs(vect[X]) < epsilon) &&
-                   (abs(vect[Y]) < epsilon) &&
-                   (abs(vect[Z]) < epsilon);
+            return (fabs(vect[X]) < epsilon) &&
+                   (fabs(vect[Y]) < epsilon) &&
+                   (fabs(vect[Z]) < epsilon);
         }
         inline GenericVector3d normalized() const
         {


### PR DESCRIPTION
Use of abs() instead of fabs() in vector functions recently created for the new user defined camera caused problems for Ubuntu users. Edit changes to fabs(). See: http://news.povray.org/povray.text.scene-files/message/%3C56e36723%241%40news.povray.org%3E/#%3C56e36723%241%40news.povray.org%3E