### PR TITLE
Adding df3, density_file query range support to max_extent.

### DIFF
--- a/source/parser/parser_expressions.cpp
+++ b/source/parser/parser_expressions.cpp
@@ -1212,6 +1212,7 @@ void Parser::Parse_Num_Factor (EXPRESS& Express,int *Terms)
                 case MAX_EXTENT_TOKEN:
                     GET (LEFT_PAREN_TOKEN);
                     EXPECT
+
                         CASE (OBJECT_ID_TOKEN)
                             Object = reinterpret_cast<ObjectPtr>(Token.Data);
                             if ( Object )
@@ -1220,13 +1221,9 @@ void Parser::Parse_Num_Factor (EXPRESS& Express,int *Terms)
                         END_CASE
 
                         // JN2007: Image map dimensions:
-                        CASE (PIGMENT_ID_TOKEN)
+                        CASE3 (DENSITY_ID_TOKEN,PIGMENT_ID_TOKEN,TNORMAL_ID_TOKEN)
                             Pigment = reinterpret_cast<PIGMENT *>(Token.Data);
-                            if((Pigment->Type != BITMAP_PATTERN) && (Pigment->Type != DENSITY_FILE_PATTERN))
-                            {
-                                Error("The parameter to max_extent must be an image map or density_file pigment identifier");
-                            }
-                            else if(Pigment->Type == BITMAP_PATTERN)
+                            if(Pigment->Type == BITMAP_PATTERN)
                             {
                                 Vect[X] = dynamic_cast<ImagePattern*>(Pigment->pattern.get())->pImage->iwidth;
                                 Vect[Y] = dynamic_cast<ImagePattern*>(Pigment->pattern.get())->pImage->iheight;
@@ -1237,6 +1234,11 @@ void Parser::Parse_Num_Factor (EXPRESS& Express,int *Terms)
                                 Vect[X] = dynamic_cast<DensityFilePattern*>(Pigment->pattern.get())->densityFile->Data->Sx;
                                 Vect[Y] = dynamic_cast<DensityFilePattern*>(Pigment->pattern.get())->densityFile->Data->Sy;
                                 Vect[Z] = dynamic_cast<DensityFilePattern*>(Pigment->pattern.get())->densityFile->Data->Sz;
+                            }
+                            else
+                            {
+                                Error("\rThe parameter to max_extent must be a bump_map, image map\r"
+                                      "or density_file form of a normal, pigment or density identifier.");
                             }
                             EXIT
                         END_CASE

--- a/source/parser/parser_expressions.cpp
+++ b/source/parser/parser_expressions.cpp
@@ -1222,15 +1222,21 @@ void Parser::Parse_Num_Factor (EXPRESS& Express,int *Terms)
                         // JN2007: Image map dimensions:
                         CASE (PIGMENT_ID_TOKEN)
                             Pigment = reinterpret_cast<PIGMENT *>(Token.Data);
-                            if(Pigment->Type != BITMAP_PATTERN)
+                            if((Pigment->Type != BITMAP_PATTERN) && (Pigment->Type != DENSITY_FILE_PATTERN))
                             {
-                                Error("The parameter to max_extent must be an image map pigment identifier");
+                                Error("The parameter to max_extent must be an image map or density_file pigment identifier");
                             }
-                            else
+                            else if(Pigment->Type == BITMAP_PATTERN)
                             {
                                 Vect[X] = dynamic_cast<ImagePattern*>(Pigment->pattern.get())->pImage->iwidth;
                                 Vect[Y] = dynamic_cast<ImagePattern*>(Pigment->pattern.get())->pImage->iheight;
                                 Vect[Z] = 0;
+                            }
+                            else if(Pigment->Type == DENSITY_FILE_PATTERN)
+                            {
+                                Vect[X] = dynamic_cast<DensityFilePattern*>(Pigment->pattern.get())->densityFile->Data->Sx;
+                                Vect[Y] = dynamic_cast<DensityFilePattern*>(Pigment->pattern.get())->densityFile->Data->Sy;
+                                Vect[Z] = dynamic_cast<DensityFilePattern*>(Pigment->pattern.get())->densityFile->Data->Sz;
                             }
                             EXIT
                         END_CASE


### PR DESCRIPTION
Enables users to determine the x,y,z ranges, returned as a vector, for
density_file based pigments matching a similar function for image maps.