### PR TITLE
Allowing the use of pigment_map in density blocks.

### DIFF
--- a/source/parser/parser_materials.cpp
+++ b/source/parser/parser_materials.cpp
@@ -1846,7 +1846,7 @@ void Parser::Parse_Pattern (PATTERN_T *New, BlendMapTypeId TPat_Type)
         CASE (COLOUR_MAP_TOKEN)
             if ((TPat_Type != kBlendMapType_Pigment) && (TPat_Type != kBlendMapType_Density))
             {
-                Only_In("color_map","pigment");
+                Only_In("color_map","pigment or density");
             }
             if (New->Type == BRICK_PATTERN ||
                 New->Type == GENERIC_INTEGER_PATTERN ||
@@ -1861,9 +1861,9 @@ void Parser::Parse_Pattern (PATTERN_T *New, BlendMapTypeId TPat_Type)
         END_CASE
 
         CASE (PIGMENT_MAP_TOKEN)
-            if (TPat_Type != kBlendMapType_Pigment)
+            if ((TPat_Type != kBlendMapType_Pigment) && (TPat_Type != kBlendMapType_Density))
             {
-                Only_In("pigment_map","pigment");
+                Only_In("pigment_map","pigment or density");
             }
             if (New->Type == BRICK_PATTERN ||
                 New->Type == GENERIC_INTEGER_PATTERN ||


### PR DESCRIPTION
In particular this enables the df3, image plane stacking done for clouds
and such to be done on the fly within povray. In general makes density
more flexible and it does it while doing all the color handling with no
additional overhead.