### PR TITLE
Adding image_map support to density.

### DIFF
--- a/source/parser/parser_materials.cpp
+++ b/source/parser/parser_materials.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
-/// Copyright 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -1548,8 +1548,10 @@ void Parser::Parse_Pattern (PATTERN_T *New, BlendMapTypeId TPat_Type)
         END_CASE
 
         CASE (IMAGE_MAP_TOKEN)
-            if (TPat_Type != kBlendMapType_Pigment)
-                Only_In("image_map","pigment");
+            if ((TPat_Type != kBlendMapType_Pigment) && (TPat_Type != kBlendMapType_Density))
+            {
+                Only_In("image_map","pigment or density");
+            }
             New->Type = IMAGE_MAP_PATTERN;
             New->pattern = PatternPtr(new ColourImagePattern());
             Parse_Image_Map (reinterpret_cast<PIGMENT *>(New));
@@ -1853,7 +1855,7 @@ void Parser::Parse_Pattern (PATTERN_T *New, BlendMapTypeId TPat_Type)
         CASE (COLOUR_MAP_TOKEN)
             if ((TPat_Type != kBlendMapType_Pigment) && (TPat_Type != kBlendMapType_Density))
             {
-                Only_In("color_map","pigment");
+                Only_In("color_map","pigment or density");
             }
             if (New->Type == AVERAGE_PATTERN || !New->pattern->CanMap())
                 Error("Cannot use color_map with this pattern type.");


### PR DESCRIPTION
A less risky alternative to adding pigment_map support to
density(#81-closed). This method also enables image slices to define a
density in a way other than the external image file slices to df3
methods. The densities would be defined with image files and those
would be used in a density_map.
