### PR TITLE
Fixing potential pattern threshold keyword use in function.

### DIFF
--- a/source/parser/parser_materials.cpp
+++ b/source/parser/parser_materials.cpp
@@ -5330,6 +5330,18 @@ void Parser::Parse_PatternFunction(TPATTERN *New)
             New->pattern = PatternPtr(new PotentialPattern());
             dynamic_cast<PotentialPattern*>(New->pattern.get())->pObject = tempObjects[0];
             Parse_End();
+
+            EXPECT
+                CASE (THRESHOLD_TOKEN)
+                    dynamic_cast<PotentialPattern*>(New->pattern.get())->subtractThreshold = Parse_Bool();
+                END_CASE
+
+                OTHERWISE
+                    UNGET
+                    EXIT
+                END_CASE
+            END_EXPECT
+
             EXIT
         }
         END_CASE


### PR DESCRIPTION
function { pattern { potential { Blob00 } threshold on } } use was
causing a scene parse error.

An example scene file for the problem fixed is attached. 

[fixPotentialThresholdInFnct.pov.txt](https://github.com/POV-Ray/povray/files/485560/fixPotentialThresholdInFnct.pov.txt)
