### PR TITLE
Fixing tiling pattern use in functions.

### DIFF
--- a/source/parser/parser_materials.cpp
+++ b/source/parser/parser_materials.cpp
@@ -5310,7 +5310,12 @@ void Parser::Parse_PatternFunction(TPATTERN *New)
             EXIT
         END_CASE
 
-        // TODO VERIFY - TILING_TOKEN is not accepted, is that ok?
+        CASE (TILING_TOKEN)
+            New->Type = TILING_PATTERN;
+            New->pattern = PatternPtr(new TilingPattern());
+            dynamic_cast<TilingPattern*>(New->pattern.get())->tilingType = (unsigned char)Parse_Float();
+            EXIT
+        END_CASE
 
         CASE (POTENTIAL_TOKEN)
         {


### PR DESCRIPTION
Fixing an issue I hit some years ago. See attached test scene file with both function -> pattern and function -> pigment variants for all tiling patterns.  

[tilingPatternsAsIsosurfacesTest.pov.txt](https://github.com/POV-Ray/povray/files/490796/tilingPatternsAsIsosurfacesTest.pov.txt)


