### PR TITLE
Adding missing close paren in 30_HF_Sphere_macro.txt

### DIFF
--- a/distribution/scenes/templates/height_field_and_HF_macros/30_HF_Sphere_macro.txt
+++ b/distribution/scenes/templates/height_field_and_HF_macros/30_HF_Sphere_macro.txt
@@ -1,7 +1,7 @@
  // ----------------- HF_Sphere macro
 #declare Fn_1 =
  function(x, y, z)
-  {1-(-f_snoise3d(x*7,y*7,z*7)*0.5 }
+  {1-(-f_snoise3d(x*7,y*7,z*7)*0.5) }
 
 object{ //----------------------------
 HF_Sphere( Fn_1, //Function,
@@ -23,5 +23,5 @@ HF_Sphere( Fn_1, //Function,
  scale<1,1,1>*1
  rotate<0,0,0>
  translate<0,0.00,0>
-}  // end of HF_Sphere ------------------- 
+}  // end of HF_Sphere -------------------
 


### PR DESCRIPTION
Reported by omniverse on povray.documentation.inbuilt.

See: 

http://news.povray.org/povray.documentation.inbuilt/message/%3Cweb.57ede719b90612ffb1933f770%40news.povray.org%3E/#%3Cweb.57ede719b90612ffb1933f770%40news.povray.org%3E
