### PR TITLE
Fix 4D vector parsing anomaly

### DIFF
--- a/source/parser/parser_expressions.cpp
+++ b/source/parser/parser_expressions.cpp
@@ -1256,8 +1256,7 @@ void Parser::Parse_Num_Factor (EXPRESS& Express,int *Terms)
                I haven't yet figured out what to do if it was expecting
                a COLOUR value with Terms>3
             */
-            if(*Terms < 3)
-                *Terms = 3;
+            *Terms = 3;
 
             for(i = 0; i < 3; i++)
                 Express[i] = Vect[i];

--- a/source/parser/parser_expressions.cpp
+++ b/source/parser/parser_expressions.cpp
@@ -1251,13 +1251,7 @@ void Parser::Parse_Num_Factor (EXPRESS& Express,int *Terms)
                     break;
             }
 
-
-            /* If it was expecting a DBL, promote it to a VECTOR.
-               I haven't yet figured out what to do if it was expecting
-               a COLOUR value with Terms>3
-            */
             *Terms = 3;
-
             for(i = 0; i < 3; i++)
                 Express[i] = Vect[i];
             EXIT


### PR DESCRIPTION
When expecting a 4D vector, the parser would erroneously treat a 3D vector as if it had 4 components, despite only setting 3 (so that the fourth component would retain whatever value was in that memory location).  (More precisely, Parse_Num_Factor would fail to update `*Terms` when parsing a 3D vector token if `*Terms>3`.)  This would cause, e.g., `julia_fractal{2/9*x}` to get parsed as if one had written `julia_fractal{2/9*<1,0,0,9>}`.

This fixes that issue.  (I also removed a nearby comment that no longer makes much sense.)