### PR TITLE
Ignore + cleanup unix/config/compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,7 @@ $RECYCLE.BIN/
 /source/Makefile.in
 /unix/Makefile.am
 /unix/Makefile.in
+/unix/config/compile
 /unix/config/config.guess
 /unix/config/config.sub
 /unix/config/depcomp

--- a/unix/prebuild.sh
+++ b/unix/prebuild.sh
@@ -138,7 +138,7 @@ echo "make maintainer-clean" 1>&2  &&  make maintainer-clean 1>&2 ; \
     rm -r ../$file 2> /dev/null  &&  echo "Cleanup ../$file"
   done
   # cleanup stuff added by automake
-  for file in config.guess config.sub depcomp install-sh missing
+  for file in config.guess config.sub compile depcomp install-sh missing
   do
     rm config/$file 2> /dev/null  &&  echo "Cleanup config/$file"
   done


### PR DESCRIPTION
Adds unix/config/compile (created by automake) to .gitignore and adds it to the cleanup list in unix/prebuild.sh.