### PR TITLE
Improving unix console messages with SDL display use.

### DIFF
--- a/unix/disp.h
+++ b/unix/disp.h
@@ -11,7 +11,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
-/// Copyright 1991-2014 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -62,7 +62,7 @@ namespace pov_frontend
             virtual bool TakeOver(UnixDisplay *display) = 0;
 
             /**
-                 To read all pending events in an interfactive display system
+                 To read all pending events in an interactive display system
                  and interpret them.
 
                  @returns true if an abort request has been made, false otherwise

--- a/unix/disp_sdl.cpp
+++ b/unix/disp_sdl.cpp
@@ -10,7 +10,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
-/// Copyright 1991-2014 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -213,7 +213,7 @@ namespace pov_frontend
 
             if ( m_display == NULL )
             {
-                fprintf(stderr, "Couldn't convert bar surface: %s\n", SDL_GetError());
+                fprintf(stderr, "Couldn't convert to optimized surface for repeated blitting: %s\n", SDL_GetError());
                 return;
             }
 
@@ -545,7 +545,7 @@ namespace pov_frontend
     {
         if (!m_valid)
             return;
-        fprintf(stderr, "Press a key or click the display to continue...");
+        fprintf(stderr, "Press p, q, enter or click the display to continue...");
         SetCaption(true);
     }
 
@@ -570,7 +570,8 @@ namespace pov_frontend
             switch (event.type)
             {
                 case SDL_KEYDOWN:
-                    if ( event.key.keysym.sym == SDLK_q || event.key.keysym.sym == SDLK_RETURN || event.key.keysym.sym == SDLK_KP_ENTER )
+                    if ( event.key.keysym.sym == SDLK_p || event.key.keysym.sym == SDLK_q ||
+                         event.key.keysym.sym == SDLK_RETURN || event.key.keysym.sym == SDLK_KP_ENTER )
                         do_quit = true;
                     break;
                 case SDL_MOUSEBUTTONDOWN:

--- a/vfe/unix/unixconsole.cpp
+++ b/vfe/unix/unixconsole.cpp
@@ -201,10 +201,32 @@ static void PrintStatusChanged (vfeSession *session, State force = kUnknown)
             fprintf (stderr, "==== [Parsing...] ==========================================================\n");
             break;
         case kRendering:
+#ifdef HAVE_LIBSDL
+            if ((gDisplay != NULL) && (gDisplayMode == DISP_MODE_SDL))
+            {
+                fprintf (stderr, "==== [Rendering... Press p to pause, q to quit] ============================\n");
+            }
+            else
+            {
+                fprintf (stderr, "==== [Rendering...] ========================================================\n");
+            }
+#else
             fprintf (stderr, "==== [Rendering...] ========================================================\n");
+#endif
             break;
         case kPausedRendering:
-            fprintf (stderr, "==== [Paused] ==============================================================\n");
+#ifdef HAVE_LIBSDL
+            if ((gDisplay != NULL) && (gDisplayMode == DISP_MODE_SDL))
+            {
+                fprintf (stderr, "==== [Paused... Press p to resume] =========================================\n");
+            }
+            else
+            {
+                fprintf (stderr, "==== [Paused...] ===========================================================\n");
+            }
+#else
+            fprintf (stderr, "==== [Paused...] ===========================================================\n");
+#endif
             break;
     }
 }


### PR DESCRIPTION
The end render message:  Press a key or click the display to continue...
for unix versions has long been inaccurate because you cannot click any
key, but rather only a few specific ones.  Pauses with 'p' also gave no
clue in the paused message to use 'p' to continue.  Update somewhat
complicated for being only text message changes due no-display runs or
compiles without SDL installed - and so no-display - not picking up
general key press events.
