### PR TITLE
Fix for subsurface crash. Issue #122 and FS306.

### DIFF
--- a/source/parser/parser_materials.cpp
+++ b/source/parser/parser_materials.cpp
@@ -2614,6 +2614,10 @@ void Parser::Parse_Finish (FINISH **Finish_Ptr)
         END_CASE
 
         CASE (SUBSURFACE_TOKEN)
+            if (sceneData->useSubsurface != true)
+            {
+                Error("Finish subsurface block seen before subsurface block set in global_settings.");
+            }
             mExperimentalFlags.subsurface = true;
             New->UseSubsurface = true;
             Parse_Begin();


### PR DESCRIPTION
Added a check in the parser that subsurface scene data true on
seeing finish subsurface block.