### PR TITLE
Fix promotion bug

### DIFF
--- a/source/parser/parser.h
+++ b/source/parser/parser.h
@@ -755,7 +755,7 @@ class Parser : public SceneTask
         void Parse_Rel_Term (EXPRESS& Express, int *Terms);
 
         /// Parses a REL_TERM comparing two strings.
-        void Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Terms);
+        DBL Parse_Rel_String_Term (const UCS2 *lhs);
 
         /// Parses a LOGICAL_EXPRESSION (including FLOAT) or VECTOR.
         void Parse_Logical (EXPRESS& Express, int *Terms);

--- a/source/parser/parser.h
+++ b/source/parser/parser.h
@@ -755,7 +755,7 @@ class Parser : public SceneTask
         void Parse_Rel_Term (EXPRESS& Express, int *Terms);
 
         /// Parses a REL_TERM comparing two strings.
-        void Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int Terms);
+        void Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Terms);
 
         /// Parses a LOGICAL_EXPRESSION (including FLOAT) or VECTOR.
         void Parse_Logical (EXPRESS& Express, int *Terms);

--- a/source/parser/parser_expressions.cpp
+++ b/source/parser/parser_expressions.cpp
@@ -1723,12 +1723,10 @@ void Parser::Parse_Rel_Factor (EXPRESS& Express,int *Terms)
 *
 ******************************************************************************/
 
-void Parser::Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Terms)
+DBL Parser::Parse_Rel_String_Term (const UCS2 *lhs)
 {
     int Val;
     UCS2 *rhs = NULL;
-
-    *Terms = 1;
 
     EXPECT_ONE
         CASE (LEFT_ANGLE_TOKEN)
@@ -1736,7 +1734,7 @@ void Parser::Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Term
             Val = UCS2_strcmp(lhs, rhs);
             POV_FREE(rhs);
 
-            Express[0] = (DBL)(Val < 0);
+            return (DBL)(Val < 0);
         END_CASE
 
         CASE (REL_LE_TOKEN)
@@ -1744,7 +1742,7 @@ void Parser::Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Term
             Val = UCS2_strcmp(lhs, rhs);
             POV_FREE(rhs);
 
-            Express[0] = (DBL)(Val <= 0);
+            return (DBL)(Val <= 0);
         END_CASE
 
         CASE (EQUALS_TOKEN)
@@ -1752,7 +1750,7 @@ void Parser::Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Term
             Val = UCS2_strcmp(lhs, rhs);
             POV_FREE(rhs);
 
-            Express[0] = (DBL)(Val == 0);
+            return (DBL)(Val == 0);
         END_CASE
 
         CASE (REL_NE_TOKEN)
@@ -1760,7 +1758,7 @@ void Parser::Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Term
             Val = UCS2_strcmp(lhs, rhs);
             POV_FREE(rhs);
 
-            Express[0] = (DBL)(Val != 0);
+            return (DBL)(Val != 0);
         END_CASE
 
         CASE (REL_GE_TOKEN)
@@ -1768,7 +1766,7 @@ void Parser::Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Term
             Val = UCS2_strcmp(lhs, rhs);
             POV_FREE(rhs);
 
-            Express[0] = (DBL)(Val >= 0);
+            return (DBL)(Val >= 0);
         END_CASE
 
         CASE (RIGHT_ANGLE_TOKEN)
@@ -1776,7 +1774,7 @@ void Parser::Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Term
             Val = UCS2_strcmp(lhs, rhs);
             POV_FREE(rhs);
 
-            Express[0] = (DBL)(Val > 0);
+            return (DBL)(Val > 0);
         END_CASE
 
         OTHERWISE
@@ -1816,7 +1814,8 @@ void Parser::Parse_Rel_Term (EXPRESS& Express,int *Terms)
     UCS2 *Local_String = Parse_String(false, false);
     if(Local_String != NULL)
     {
-            Parse_Rel_String_Term(Local_String, Express, Terms);
+            *Terms = 1;
+            Express[0] = Parse_Rel_String_Term(Local_String);
             POV_FREE(Local_String);
             Ok_To_Declare = old_Ok_To_Declare;
             return;

--- a/source/parser/parser_expressions.cpp
+++ b/source/parser/parser_expressions.cpp
@@ -1107,8 +1107,7 @@ void Parser::Parse_Num_Factor (EXPRESS& Express,int *Terms)
             }
 
             *Terms = 1;
-            for (i=0; i < *Terms; i++)
-                Express[i]=Val;
+            Express[0]=Val;
             EXIT
         END_CASE
 
@@ -1262,8 +1261,7 @@ void Parser::Parse_Num_Factor (EXPRESS& Express,int *Terms)
         CASE (FUNCT_ID_TOKEN)
             *Terms = 1;
             Val = Parse_Function_Call();
-            for(i = 0; i < *Terms; i++)
-                Express[i] = Val;
+            Express[0] = Val;
             EXIT
         END_CASE
 
@@ -1366,7 +1364,7 @@ void Parser::Parse_Num_Factor (EXPRESS& Express,int *Terms)
 
             EXPECT
                 CASE_EXPRESS
-                    /* If a 3th float is found, parse it. */
+                    /* If a 3rd float is found, parse it. */
                     Express[2] = Parse_Float(); Parse_Comma();
                     *Terms=3;
                     EXPECT
@@ -1727,7 +1725,7 @@ void Parser::Parse_Rel_Factor (EXPRESS& Express,int *Terms)
 
 void Parser::Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Terms)
 {
-    int Val, i;
+    int Val;
     UCS2 *rhs = NULL;
 
     *Terms = 1;
@@ -1738,8 +1736,7 @@ void Parser::Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Term
             Val = UCS2_strcmp(lhs, rhs);
             POV_FREE(rhs);
 
-            for(i=0;i<*Terms;i++)
-                Express[i] = (DBL)(Val < 0);
+            Express[0] = (DBL)(Val < 0);
         END_CASE
 
         CASE (REL_LE_TOKEN)
@@ -1747,8 +1744,7 @@ void Parser::Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Term
             Val = UCS2_strcmp(lhs, rhs);
             POV_FREE(rhs);
 
-            for(i=0;i<*Terms;i++)
-                Express[i] = (DBL)(Val <= 0);
+            Express[0] = (DBL)(Val <= 0);
         END_CASE
 
         CASE (EQUALS_TOKEN)
@@ -1756,8 +1752,7 @@ void Parser::Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Term
             Val = UCS2_strcmp(lhs, rhs);
             POV_FREE(rhs);
 
-            for(i=0;i<*Terms;i++)
-                Express[i] = (DBL)(Val == 0);
+            Express[0] = (DBL)(Val == 0);
         END_CASE
 
         CASE (REL_NE_TOKEN)
@@ -1765,8 +1760,7 @@ void Parser::Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Term
             Val = UCS2_strcmp(lhs, rhs);
             POV_FREE(rhs);
 
-            for(i=0;i<*Terms;i++)
-                Express[i] = (DBL)(Val != 0);
+            Express[0] = (DBL)(Val != 0);
         END_CASE
 
         CASE (REL_GE_TOKEN)
@@ -1774,8 +1768,7 @@ void Parser::Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Term
             Val = UCS2_strcmp(lhs, rhs);
             POV_FREE(rhs);
 
-            for(i=0;i<*Terms;i++)
-                Express[i] = (DBL)(Val >= 0);
+            Express[0] = (DBL)(Val >= 0);
         END_CASE
 
         CASE (RIGHT_ANGLE_TOKEN)
@@ -1783,8 +1776,7 @@ void Parser::Parse_Rel_String_Term (const UCS2 *lhs, EXPRESS& Express, int *Term
             Val = UCS2_strcmp(lhs, rhs);
             POV_FREE(rhs);
 
-            for(i=0;i<*Terms;i++)
-                Express[i] = (DBL)(Val > 0);
+            Express[0] = (DBL)(Val > 0);
         END_CASE
 
         OTHERWISE
@@ -1980,12 +1972,12 @@ void Parser::Parse_Express (EXPRESS& Express,int *Terms)
             Parse_Express(Local_Express2,&Local_Terms2);
             if (ftrue(Express[0]))
             {
-                Chosen = reinterpret_cast<EXPRESS *>(&Local_Express1);
+                Chosen = &Local_Express1;
                 *Terms = Local_Terms1;
             }
             else
             {
-                Chosen = reinterpret_cast<EXPRESS *>(&Local_Express2);
+                Chosen = &Local_Express2;
                 *Terms = Local_Terms2;
             }
             POV_MEMCPY(Express,Chosen,sizeof(EXPRESS));
@@ -2787,7 +2779,7 @@ void Parser::Parse_Wavelengths (MathColour& colour)
 *
 *   Chris Young 11/94
 *
-* DESCRIPTION   :
+* DESCRIPTION
 *
 * CHANGES
 *
@@ -3390,8 +3382,8 @@ template TextureBlendMapPtr Parser::Parse_Item_Into_Blend_List<TextureBlendMap> 
 *
 *   POV-Ray Team
 *
-* DESCRIPTION   : This seperate routine parses color_maps only.  It
-*                 cannot be used for pigment_maps because it accomidates
+* DESCRIPTION   : This separate routine parses color_maps only.  It
+*                 cannot be used for pigment_maps because it accommodates
 *                 the old double entry color maps from vers 1.0
 *
 * CHANGES
@@ -3586,7 +3578,7 @@ TextureBlendMapPtr Parser::Parse_Colour_Map<TextureBlendMap> ()
 *
 *   Wolfgang Ortmann
 *
-* DESCRIPTION   : This seperate routine parses pure splines only. Splines in
+* DESCRIPTION   : This separate routine parses pure splines only. Splines in
 *   lathe objects and SOR are similar but not identical
 *
 * CHANGES
@@ -3929,7 +3921,7 @@ DBL Parser::Parse_Signed_Float(void)
         CASE (DASH_TOKEN)
             Sign=-1.0;
             Get_Token();
-            /* Deliberate fall through with no END_CASE */
+            // FALLTHROUGH
         CASE (FLOAT_FUNCT_TOKEN)
             if (Token.Function_Id==FLOAT_TOKEN)
             {


### PR DESCRIPTION
This fixes the bug reported in http://news.povray.org/3c4bb31d$1@news.povray.org.  (This also does some general cleanup of source/parser/parser_expressions.cpp.)

(Promotion was occurring before it was needed, causing (sub-)expressions to produce different results depending on context.  For instance, floats were being directly promoted by `Parse_Num_Factor`, causing, e.g.: `<1,0,0>+1*t` to parse as `<1,0,0>+<1,1,1>*t` and thence `<1,0,0>+<1,1,1,0>*<0,0,0,1>` (the bug reported).  This has been fixed by removing uses of `*Terms` as an input parameter to functions (but still using it as an output parameter).)
