### PR TITLE
Port of JG uv_mapping for cylinder and cone.

### DIFF
--- a/source/core/shape/cone.h
+++ b/source/core/shape/cone.h
@@ -80,7 +80,7 @@ class Cone : public ObjectBase
         virtual bool All_Intersections(const Ray&, IStack&, TraceThreadData *);
         virtual bool Inside(const Vector3d&, TraceThreadData *) const;
         virtual void Normal(Vector3d&, Intersection *, TraceThreadData *) const;
-        // virtual void UVCoord(Vector2d&, const Intersection *, TraceThreadData *) const; // TODO FIXME - why is there no UV-mapping for this simple object?
+        virtual void UVCoord(Vector2d&, const Intersection *, TraceThreadData *) const;
         virtual void Translate(const Vector3d&, const TRANSFORM *);
         virtual void Rotate(const Vector3d&, const TRANSFORM *);
         virtual void Scale(const Vector3d&, const TRANSFORM *);
@@ -91,6 +91,7 @@ class Cone : public ObjectBase
         void Compute_Cylinder_Data();
     protected:
         int Intersect(const BasicRay& ray, CONE_INT *Intersection, TraceThreadData *Thread) const;
+        void CalcUV(const Vector3d& IPoint, Vector2d& Result) const;
 };
 
 }


### PR DESCRIPTION
Note I flipped the UV mapping in V as it looked upside down to the usual
POV-Ray UV mapping. Related comments in the code.

Attaching a test scene file: 

[mappings.pov.txt](https://github.com/POV-Ray/povray/files/550409/mappings.pov.txt)
