### PR TITLE
Flipping uv_mapping of torus in U to usual orientation.

### DIFF
--- a/source/core/shape/torus.cpp
+++ b/source/core/shape/torus.cpp
@@ -1118,7 +1118,7 @@ void Torus::CalcUV(const Vector3d& IPoint, Vector2d& Result) const
     z = P[Z];
 
     // Determine its angle from the y-axis.
-    u = (1.0 - (atan2(z, x) + M_PI) / TWO_M_PI);
+    u = (atan2(-z,-x) + M_PI) / TWO_M_PI;
 
     len = sqrt(x * x + z * z);
 


### PR DESCRIPTION
See :

http://news.povray.org/povray.beta-test/thread/%3C580cd1a7%241%40news.povray.org%3E/

and attached scene file.

[mappings.pov.txt](https://github.com/POV-Ray/povray/files/550403/mappings.pov.txt)

If we decide to leave the torus uv_mapping as is closing this pull request, the documentation is currently vague enough we could just leave it to users to figure out this mapping different. Or we could document it is reversed in U from the usual rotation around Y for POV-Ray.
