### PR TITLE
Adding column wrap control for unix console and files.

### DIFF
--- a/source/base/textstreambuffer.cpp
+++ b/source/base/textstreambuffer.cpp
@@ -38,6 +38,7 @@
 
 // C++ variants of standard C header files
 #include <cstring>
+#include <cstdlib>
 
 // Standard C++ header files
 #include <algorithm>
@@ -58,6 +59,12 @@ TextStreamBuffer::TextStreamBuffer(size_t buffersize, unsigned int wrapwidth)
     boffset = 0;
     bsize = buffersize;
     wrap = wrapwidth;
+    if (const char* env_p = std::getenv("POVRAY_TEXTSTREAM_COLUMNS"))
+    {
+        if (wrap==80U)
+            wrap = std::max((long)wrap,std::strtol(env_p,NULL,10));
+        wrap = std::min(wrap,999U);
+    }
     curline = 0;
     buffer = new char[bsize];
     if(buffer == NULL)

--- a/vfe/vfesession.cpp
+++ b/vfe/vfesession.cpp
@@ -75,6 +75,12 @@ vfeSession::vfeSession(int id)
   m_MaxConsoleMessages = -1;
   m_OptimizeForConsoleOutput = true;
   m_ConsoleWidth = 80;
+  if (const char* env_p = std::getenv("POVRAY_CONSOLE_COLUMNS"))
+  {
+      m_ConsoleWidth = std::max((long)m_ConsoleWidth,std::strtol(env_p,NULL,10));
+      m_ConsoleWidth = std::min(m_ConsoleWidth,999);
+    //std::cout << "Console column width by POVRAY_CONSOLE_COLUMNS: " << m_ConsoleWidth << '\n';
+  }
   m_RequestFlag = rqNoRequest;
   m_RequestResult = 0;
   m_StartTime = 0;


### PR DESCRIPTION
(NOTE! Ignore this pull request for now. Submitted to run the automatic checks) 

Enabling control of the wrapping via environment variables of
POVRAY_CONSOLE_COLUMNS for the console and POVRAY_TEXTSTREAM_COLUMNS
for files and console.

If only POVRAY_TEXTSTREAM_COLUMNS set, it is used for both the console
and file wrap settings. If both are used and not the default of 80 characters,
POVRAY_CONSOLE_COLUMNS is used for the console width and
POVRAY_TEXTSTREAM_COLUMNS for all other text output streams.

POVRAY_CONSOLE_COLUMNS can be used alone.

There is an almost universal shell variable of COLUMNS in today's unix variants.
It can for example be used to set POVRAY_CONSOLE_COLUMNS using export (or set
for c shell) by typing this in the terminal window where POV-Ray will run :

export POVRAY_CONSOLE_COLUMNS=$COLUMNS

then

povray ....

A wrapper script can also be set up with perhaps the name povray.sh and
the following lines which will grab the current window width:

export POVRAY_CONSOLE_COLUMNS=$COLUMNS
povray $@

which would then be 'sourced' in the current shell terminal window:

source povray.sh +Imy.pov

or more commonly perhaps as:

. povray.sh +Imy.pov