### PR TITLE
Fix placement of break statement in Solve_Polynomial.

### DIFF
--- a/source/core/math/polynomialsolver.cpp
+++ b/source/core/math/polynomialsolver.cpp
@@ -1705,9 +1705,9 @@ int Solve_Polynomial(int n, const DBL *c0, DBL *r, int sturm, DBL epsilon, Rende
                     stats[Roots_Eliminated]++;
 
                     roots = polysolve(n-1, c, r);
-                }
 
-                break;
+                    break;
+                }
             }
 
             /* Solve n-th order polynomial. */


### PR DESCRIPTION
See:

http://news.povray.org/povray.programming/thread/%3Cweb.580874a6f9e539ccf4af9d600%40news.povray.org%3E/

Likely Christoph this change already done in your local code, but this pull
req in place to be sure we don't forget it. Jerome has already updated his hg-povray.