### PR TITLE
link with -lboost_date_time

### DIFF
--- a/unix/configure.ac
+++ b/unix/configure.ac
@@ -310,7 +310,7 @@ fi
 AC_MSG_CHECKING([whether the boost thread library is usable])
 SAVED_LIBS=$LIBS
 boost_thread_links=0
-for extralib in '' '-lboost_system'
+for extralib in '' '-lboost_system -lboost_date_time'
 do
   LIBS=$SAVED_LIBS
   LIBS="$LIBS $extralib"


### PR DESCRIPTION
i686-uhu-linux-g++  -pipe -Wno-multichar -Wno-write-strings -fno-enforce-eh-specs -Wno-non-template-friend -s -minline-all-stringops -malign-double -pthread  -L/usr/lib  -L/usr/lib -o povray disp_sdl.o disp_text.o ../vfe/libvfe.a ../source/libpovray.a ../vfe/libvfe.a ../platform/libplatform.a -lSDL -lSDL -lpthread -lXpm  -lSM -lICE -lX11  -ltiff -ljpeg -lpng -lz -lrt -lm -lboost_thread  -pthread  -lboost_system
../source/libpovray.a(metadata.o): In function `boost::date_time::month_formatter<boost::gregorian::greg_month, boost::date_time::iso_extended_format<char>, char>::format_month(boost::gregorian::greg_month const&, std::ostream&)':
metadata.cpp:(.text._ZN5boost9date_time15month_formatterINS_9gregorian10greg_monthENS0_19iso_extended_formatIcEEcE12format_monthERKS3_RSo[_ZN5boost9date_time15month_formatterINS_9gregorian10greg_monthENS0_19iso_extended_formatIcEEcE12format_monthERKS3_RSo]+0x26): undefined reference to `boost::gregorian::greg_month::as_short_string()const'
metadata.cpp:(.text._ZN5boost9date_time15month_formatterINS_9gregorian10greg_monthENS0_19iso_extended_formatIcEEcE12format_monthERKS3_RSo[_ZN5boost9date_time15month_formatterINS_9gregorian10greg_monthENS0_19iso_extended_formatIcEEcE12format_monthERKS3_RSo]+0x48): undefined reference to `boost::gregorian::greg_month::as_long_string() const'
collect2: error: ld returned 1 exit status