### PR TITLE
[ci skip] Updating the unix man page. Small typo.

### DIFF
--- a/source/frontend/processrenderoptions.cpp
+++ b/source/frontend/processrenderoptions.cpp
@@ -1078,7 +1078,7 @@ struct ProcessRenderOptions::Output_FileType_Table FileTypeTable[] =
     { 'S',  0,                              kPOVList_FileType_System,           SYS_GRAYSCALE_FLAG, SYS_ALPHA_FLAG },
 #endif // POV_SYS_IMAGE_TYPE
 
-    //  [1] Alpha support for BMP uses an inofficial extension to the BMP file format, which is not recognized by
+    //  [1] Alpha support for BMP uses an unofficial extension to the BMP file format, which is not recognized by
     //      most image pocessing software.
 
     //  [2] While OpenEXR does support greyscale output at >8 bits, the variants currently supported by POV-Ray

--- a/unix/povray.1
+++ b/unix/povray.1
@@ -1,14 +1,14 @@
-.TH POV-Ray 1 "August 2013" "POV\-Team" "Version 3.7" \" -*- nroff -*-
+.TH POV-Ray 1 "December 2016" "POV\-Team" "Version 3.71" \" -*- nroff -*-
 .\" man page written by Andreas Dilger
 .\" updated by Mark Gordon for POV-Ray 3.5
 .\" updated by Nicolas Calimet and Christoph Hormann for POV-Ray 3.6
 .\" updated by James Holsenback for POV-Ray 3.7
 
 .SH NAME
-povray \- POV\-Ray: The Persistence of Vision Ray Tracer 
+povray \- POV\-Ray: The Persistence of Vision Ray Tracer
 
 .SH SYNOPSIS
-\fBpovray\fP [\fB+O\fP\fIoutput_file\fP] [\fB+/\-option\fP ...] 
+\fBpovray\fP [\fB+O\fP\fIoutput_file\fP] [\fB+/\-option\fP ...]
 [\fIinput_file\fP]
 .LP
 \fBpovray\fP [\fB+I\fP\fIinput_file\fP] [\fB+O\fP\fIoutput_file\fP]
@@ -16,33 +16,25 @@ povray \- POV\-Ray: The Persistence of Vision Ray Tracer
 
 .SH DESCRIPTION
 \fBPOV\-Ray\fP is a free, full\-featured ray tracer, written and maintained
-by a team of volunteers on the Internet.  On the UNIX platform \fBPOV\-Ray\fP 
-can be compiled with support for preview capabilities using the \fIX Window 
-System\fP.
+by a team of volunteers on the Internet.  On the UNIX platform \fBPOV\-Ray\fP
+can be compiled with support for preview capabilities using the Simple
+DirectMedia Layer V1.2 library (https://www.libsdl.org).
 .LP
 This manual page only lists the basic \fBPOV\-Ray\fP and UNIX specific
 features and command\-line options for this version of \fBPOV\-Ray\fP.
 For a complete description of the features of \fBPOV\-Ray\fP and
 its scene description language (a.k.a. \fBPOV\-Ray\fP SDL),
 or for a better explanation of the meaning of the
-command\-line and INI file options, please consult the documentation
-that should accompany all versions of \fBPOV\-Ray\fP.  The documentation
+command\-line and INI file options, please consult the online documentation
+at http://wiki.povray.org/content/Documentation:Contents or the documentation
+capture that should accompany all versions of \fBPOV\-Ray\fP. The documentation
 is installed in PREFIX/share/doc/povray-3.7, where PREFIX is /usr/local
 by default, or a path specified when configuring the source package for
 compilation and installation.
 .LP
+http://www.povray.org
+.LP
 Some of the UNIX\-specific features are:
-.IP
-Support for X Window display automatically uses the best visual class
-and deepest depth available.  For visuals that do not support 24 bits of
-color per pixel, Floyd\-Steinberg error diffusion dithering is used, along
-with a dynamically allocated and optimized palette to produce the best
-display possible with the current visual, depth, and available colormap.
-.IP
-ICCCM compliance for the X Window version means that the preview window
-will behave like standard X Window programs, communicate properly with
-the window manager, and will accept the standard command\-line options.
-See \fIX(1)\fP for more information.
 .IP
 ASCII graphics in the text\-mode version allow a basic view of
 the current rendering on text\-only terminals.
@@ -62,7 +54,7 @@ Many options are switches, meaning a '+' turns the option on, and a '\-'
 turns the option off.  For other options, it doesn't matter if
 a '+' or a '\-' is used.  Most options cannot have spaces in them
 so you should specify \fB+FN\fP rather than \fB+F N\fP, and combining
-options is not allowed, so \fB+SC\fB is very different from \fB+S +C\fP.
+options is not allowed, so \fB+SC\fP is very different from \fB+S +C\fP.
 Options are not case sensitive.
 .LP
 The command\-line options are shown below with their corresponding INI
@@ -138,7 +130,10 @@ End the rendering at column \fIn\fP from the left of the screen.
 End the rendering at \fIn\fP percent from the left of the screen.
 .TP
 \fBC\fP or \fBContinue_Trace\fP=\fIbool\fP
-Continue a previously interrupted trace.
+Continue a previously interrupted scene trace.
+.TP
+\fBCC\fP or \fBCreate_Continue_Trace_Log\fP=\fIbool\fP
+Create trace state file needed to later continue an interrupted scene trace.
 .TP
 \fBP\fP or \fBPause_When_Done\fP=\fIbool\fP
 If previewing, pause when the rendering is complete before closing the window.
@@ -148,23 +143,11 @@ Output verbose status messages on the progress of the rendering.
 .TP
 \fBWL\fP\fIn\fP or \fBWarning_Level\fP=\fIinteger\fP
 Set warning level to \fIn\fP.
-.TP
-\fBX\fP or \fBTest_Abort\fP=\fIbool\fP
-Enable the 'q' and 'Q' keys to interrupt a rendering in progress.
-.TP
-\fBX\fP\fIn\fP or \fBTest_Abort_Count\fP=\fIinteger\fP
-Only check every \fIn\fP pixels for a user abort.
 
 .SS Output options \- display related:
 .TP
-\fBD\fP[0][\fIGHT\fP] or \fBDisplay\fP=\fIbool\fP  \fBPalette\fP=\fIchar\fP
-Display the rendering in progress, optionally specifying the palette.
-The only valid X Window palette option is \fIG\fP, which forces
-grayscale preview.  The X Window palette is based on the visual used,
-whether selected automatically by \fBPOV\-Ray\fP or via the \fB\-visual\fP
-option.  To specify the palette, you must first specify the display
-type (the second character, shown here as '0') for compatibility reasons,
-even though it is ignored in UNIX versions.
+\fBD\fP or \fBDisplay\fP=\fIbool\fP
+Turns graphic display on/off, if program built with Simple DirectMedia Layer library.
 .TP
 \fBSP\fP\fIn\fP or \fBPreview_Start_Size\fP=\fIinteger\fP
 Start mosaic preview with blocks \fIn\fP pixels square.
@@ -176,9 +159,11 @@ End mosaic preview with blocks \fIn\fP pixels square.
 Draw vista rectangles before rendering has been deprecated.
 .SS Output options \- file related:
 .TP
-\fBF\fP[\fICEHJNPST\fP][\fIn\fP] or \fBOutput_to_File\fP=\fIbool\fP \fBOutput_File_Type\fP=\fIchar\fP
-Store the rendered image using one of the available formats, namely
-\fIC\fPompressed TGA, Open\fIE\fPXR, Radiance \fIH\fPigh Dynamic-Range, \fIJ\fPPEG, P\fIN\fPG, \fIP\fPPM, \fIS\fPystem  specific (PNG) and \fIT\fPGA.
+\fBF\fP[\fIBCEHJNPT\fP][\fIn\fP] or \fBOutput_to_File\fP=\fIbool\fP \fBOutput_File_Type\fP=\fIchar\fP
+Store the rendered image using one of the available formats, namely  \fIB\fPMP,
+\fIC\fPompressed TGA, Open\fIE\fPXR, Radiance \fIH\fPigh Dynamic-Range, \fIJ\fPPEG, P\fIN\fPG, \fIP\fPPM,
+and \fIT\fPGA given all the image libraries are available. If no image output option
+specified, output defaults to (PNG).
 .TP
 \fBO\fP<\fIoutput_file\fP> or \fBOutput_File_Name\fP=\fIfile\fP
 Write the output to the file named \fIoutput_file\fP, or the standard
@@ -256,10 +241,10 @@ into the animation.
 Generate clock values for a cyclic animation.
 .TP
 \fBUF\fP or \fBField_Render\fP=\fIbool\fP
-Render alternate frames using odd/even fields, suitable for interlaced output.
+Rendering alternate frames using odd/even fields has been deprecated.
 .TP
 \fBUO\fP or \fBOdd_Field\fP=\fIbool\fP
-Start a field rendered animation on the odd field, rather than the even field.
+Starting a field rendered animation on the odd field rather than the even field has been deprecated.
 
 .SS Redirecting options:
 .TP
@@ -272,41 +257,15 @@ Write the stream to the console and/or the specified file.  The streams are
 \fIA\fPll_File (except status), \fID\fPebug_File, \fIF\fPatal_File,
 \fIR\fPender_File, \fIS\fPtatistics_File, and the \fIW\fParning_File.
 
-.SS X Window System options:
-In addition to the standard command\-line options, POV\-Ray recognizes
-additional command\-line switches related to the X Window System.  
-See \fIX(1)\fP for a complete description of these options.
+.SS Exit status:
 .TP
-\fB\-display\fP <\fIdisplay_name\fP>
-Display preview on \fIdisplay_name\fP rather than the default display.
-This is meant to be used to change the display to a remote host.  The
-normal dispay option \fB+d\fP is still valid.
+\fB0\fP  if OK,
 .TP
-\fB\-geometry\fP  [\fIWIDTH\fPx\fIHEIGHT\fP][+\fIXOFF\fP+\fIYOFF\fP]
-Render the image with \fIWIDTH\fP and \fIHEIGHT\fP as the dimensions,
-and locate the window \fIXOFF\fP from the left edge, and \fIYOFF\fP from
-the top edge of the screen (or if negative the right and bottom edges
-respectively).  The \fIWIDTH\fP and \fIHEIGHT\fP, if given, override any
-previous \fBW\fP\fIn\fP and \fBH\fP\fIn\fP settings.
 .TP
-\fB\-help\fP
-Display the X Window System\-specific options.  Use \fB\-H\fP by itself on the
-command\-line to output the general \fBPOV\-Ray\fP options.
+\fB1\fP  if minor problems (e.g. invalid options),
 .TP
-\fB\-icon\fP
-Start the preview window as an icon.
 .TP
-\fB\-title\fP <\fIwindow_title\fP>
-Override the default preview window title with \fIwindow_title\fP.
-.TP
-\fB\-visual\fP <\fIvisual_type\fP>
-Use the deepest visual of \fIvisual_type\fP, if available, instead of
-the automatically selected visual.  Valid visuals are StaticGray,
-GrayScale, StaticColor, PseudoColor, TrueColor, or DirectColor.
-
-.SH RESOURCES
-Currently no X resource or app\-default files are supported for the X
-Window options.
+\fB>1\fP if serioues trouble (e.g. Sementation fault).
 
 .SH FILES
 .LP
@@ -333,74 +292,74 @@ In \fBPOV-Ray\fP 3.7 the format of these configuration files has changed,
 and no backward compatibility is retained with the configuration files
 in \fBPOV-Ray\fP 3.5. See the documentation for further details and
 examples of I/O Restriction settings.
-.LP
-\fIpovlegal.doc\fP should accompany all installations of \fBPOV\-Ray\fP,
-and outlines specific conditions and restrictions on the \fBPOV\-Ray\fP
-software.  A condition of \fIpovlegal.doc\fP requires that documentation,
-INI and scene files be available to all users of \fBPOV\-Ray\fP. Scene
-and INI files are typically installed in PREFIX/share/povray\-3.7, and
-documentation in PREFIX/share/doc/povray-3.7, but these may be in other
-locations on some systems.
-.LP
-The most recent version of \fBPOV\-Ray\fP and its documentation can always
-be retrieved via anonymous FTP at \fIftp.povray.org\fP or via HTTP at
-\fIpovray.org\fP, as well as many other locations.
 
 .SH SEE ALSO
-X(1), kill(1), \fIThe POV-Ray Manual\fP
+kill(1) and Full documentation at:
+  http://wiki.povray.org/content/Documentation:Contents
+
 
 .SH COPYRIGHT
-\fBPersistence of Vision Ray Tracer\fP (POV\-Ray)
-  Copyright 1991-2013 Persistence of Vision Raytracer Pty. Ltd.
+Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
+Copyright (c) 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
 .LP
-For further information see the file \fIpovlegal.doc\fP that comes
-with this program.
+POV-Ray is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
 .LP
-The \fIX Window System\fP is
-  Copyright 1984 \- 1991 the Massachusetts Institute of Technology
-  Copyright 1992 \- 1996 the X Consortium, Inc.
-  Copyright 1998        the Open Group, L.L.C.
-  Copyright 1999 \- 2004 the X.Org Foundation, L.L.C.
+POV-Ray is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+.LP
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .SH TRADEMARKS
-The terms \fIPersistence of Vision Raytracer\fP and \fIPOV-Ray\fP
+The terms \fIPersistence of Vision Raytracer\fP, \fIPOV-Team\fP and \fIPOV-Ray\fP
 are trademarks of Persistence of Vision Raytracer Pty. Ltd.
 
 UNIX is a registered trademark of The Open Group in the US and other
 countries.
 
 .SH BUGS
-Before reporting a bug to our bug-tracking system \fIbugs.povray.org\fP you
+Before reporting a bug to our bug-tracking system
+\fIhttps://github.com/POV-Ray/povray/issues\fP you
 should make sure you have the latest version of the software, in case the bug
 has already been fixed. There are a large number of \fBPOV\-Ray\fP users on the
-\fBPOV\-Ray\fP newsserver \fInews.povray.org\fP and a list of available groups
-can be found on \fIpovray.org/resources/newsgroups\fP. You should try to find
+\fBPOV\-Ray\fP newsserver \fInews.povray.org\fP availble by a web interface at:
+http://news.povray.org/groups. You should try to find
 help and assistance in there before lodging a bug report.
 
 .SH AUTHORS
-Primary POV-Ray 3.7 Architects/Developers: (Alphabetically)
+Primary POV-Ray 3.71 Architects/Developers: (Alphabetically)
 .LP
   Chris Cason         Thorsten Froehlich  Christoph Lipka
-.LP 
+.LP
 With Assistance From: (Alphabetically)
 .LP
-  Nicolas Calimet     Jerome Grimbert     James Holsenback    Christoph Hormann 
-  Nathan Kopp         Juha Nieminen
+  Nicolas Calimet     Jerome Grimbert     James Holsenback
+  Christoph Hormann   Nathan Kopp         Juha Nieminen
+  William F. Pokorny
 .LP
 Past Contributors: (Alphabetically)
 .LP
-  Steve Anger         Eric Barish         Dieter Bayer        David K. Buck     
-  Nicolas Calimet     Chris Cason         Aaron A. Collins    Chris Dailey      
-  Steve Demlow        Andreas Dilger      Alexander Enzmann   Dan Farmer        
-  Thorsten Froehlich  Mark Gordon         James Holsenback    Christoph Hormann 
-  Mike Hough          Chris Huff          Kari Kivisalo       Nathan Kopp       
-  Lutz Kretzschmar    Christoph Lipka     Jochen Lippert      Pascal Massimino  
-  Jim McElhiney       Douglas Muir        Juha Nieminen       Ron Parker        
-  Bill Pulver         Eduard Schwan       Wlodzimierz Skiba   Robert Skinner    
-  Yvo Smellenbergh    Zsolt Szalavari     Scott Taylor        Massimo Valentini 
-  Timothy Wegner      Drew Wells          Chris Young        
+  Steve Anger         Eric Barish         Dieter Bayer
+  David K. Buck       Nicolas Calimet     Chris Cason
+  Aaron A. Collins    Chris Dailey        Steve Demlow
+  Andreas Dilger      Alexander Enzmann   Dan Farmer
+  Thorsten Froehlich  Mark Gordon         James Holsenback
+  Christoph Hormann   Mike Hough          Chris Huff
+  Kari Kivisalo       Nathan Kopp         Lutz Kretzschmar
+  Christoph Lipka     Jochen Lippert      Pascal Massimino
+  Jim McElhiney       Douglas Muir        Juha Nieminen
+  Ron Parker          Bill Pulver         Eduard Schwan
+  Wlodzimierz Skiba   Robert Skinner      Yvo Smellenbergh
+  Zsolt Szalavari     Scott Taylor        Massimo Valentini
+  Timothy Wegner      Drew Wells          Chris Young
 .LP
-Other contributors are listed in the documentation.
+Other contributors are listed in the documentation at:
+  http://wiki.povray.org/content/Documentation
 
 .SH ACKNOWLEDGEMENT
 \fBPOV\-Ray\fP is based on DKBTrace 2.12 by David K. Buck and


### PR DESCRIPTION
Updating our unix man page to be current with recent 3.71 master.
Also small typo in processrenderoptions.cpp.