### PR TITLE
Fixing issues with bounding threshold option.

### DIFF
--- a/source/backend/control/scene.cpp
+++ b/source/backend/control/scene.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
-/// Copyright 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -163,7 +163,11 @@ void Scene::StartParser(POVMS_Object& parseOptions)
 
     // do bounding - we always call this even if the bounding is turned off
     // because it also generates object statistics
-    sceneThreadData.push_back(dynamic_cast<TraceThreadData *>(parserTasks.AppendTask(new BoundingTask(sceneData, parseOptions.TryGetInt(kPOVAttrib_BoundingThreshold, 1)))));
+    sceneThreadData.push_back(dynamic_cast<TraceThreadData *>
+    (parserTasks.AppendTask(new BoundingTask(sceneData,
+    clip<int>(parseOptions.TryGetInt(kPOVAttrib_BoundingThreshold, DEFAULT_AUTO_BOUNDINGTHRESHOLD),1,SIGNED16_MAX))
+    ))
+    );
 
     // wait for bounding
     parserTasks.AppendSync();

--- a/source/base/configbase.h
+++ b/source/base/configbase.h
@@ -721,6 +721,19 @@
 #define DEFAULT_WORKING_GAMMA       1.0
 #define DEFAULT_WORKING_GAMMA_TEXT  "1.0"
 
+/// @def DEFAULT_AUTO_BOUNDINGTHRESHOLD
+/// Define the default auto-bounding threshold used and reported.
+///
+/// The shipped povray.ini file defines this with:
+/// Bounding_Threshold=3
+/// and the definition here should be aligned so when users run
+/// without the bounding threshold setting by ini file or command
+/// line option the default is still the documented value of 3.
+///
+#ifndef DEFAULT_AUTO_BOUNDINGTHRESHOLD
+    #define DEFAULT_AUTO_BOUNDINGTHRESHOLD 3
+#endif
+
 #ifndef CDECL
     #define CDECL
 #endif

--- a/source/frontend/renderfrontend.cpp
+++ b/source/frontend/renderfrontend.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
-/// Copyright 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -943,7 +943,8 @@ void RenderOptions(POVMS_Object& obj, TextStreamBuffer *tsb)
     tsb->printf("  Quality: %2d\n", clip(obj.TryGetInt(kPOVAttrib_Quality, 9), 0, 9));
 
     if(obj.TryGetBool (kPOVAttrib_Bounding, true))
-        tsb->printf("  Bounding boxes.......On   Bounding threshold: %d\n", obj.TryGetInt (kPOVAttrib_BoundingThreshold, 3));
+        tsb->printf("  Bounding boxes.......On   Bounding threshold: %d\n",
+        clip<int>(obj.TryGetInt(kPOVAttrib_BoundingThreshold,DEFAULT_AUTO_BOUNDINGTHRESHOLD),1,SIGNED16_MAX));
     else
         tsb->printf("  Bounding boxes.......Off\n");
 


### PR DESCRIPTION
Related to ussues #59 and #180. When no bounding threshold is specified
centralizes centralizes the setting and reporting of the bounding
threshold to 3. Further, restores the clamping of values to 1+ which
existed in 3.6.

In deciding to apply this fix to the 3.71 release, this change was
re-based onto release/v3.7.1 and a new pull request create replacing
request #181 against the master branch.