### PR TITLE
Adding POV_THREAD_STACK_SIZE macro.

### DIFF
--- a/source/backend/configbackend.h
+++ b/source/backend/configbackend.h
@@ -10,7 +10,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
-/// Copyright 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -74,6 +74,20 @@
 ///
 #ifndef POV_USE_DEFAULT_TASK_CLEANUP
     #define POV_USE_DEFAULT_TASK_CLEANUP 1
+#endif
+
+/// @def POV_THREAD_STACK_SIZE
+///     Internally defaulted thread stack size which the user can override.
+///
+/// @note
+///     The defaulted minimum is 2MB, but later defaulted to 4MB for unix due user regression.
+///
+#ifndef POV_THREAD_STACK_SIZE
+    #define POV_THREAD_STACK_SIZE (1024 * 1024 * 2)
+#else
+    #if POV_THREAD_STACK_SIZE < (1024 * 64)
+        #error "POV_THREAD_STACK_SIZE set less than 65KB or not a byte count."
+    #endif
 #endif
 
 /// @def POV_CONVERT_TEXT_TO_UCS2

--- a/source/backend/support/task.cpp
+++ b/source/backend/support/task.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
-/// Copyright 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -103,7 +103,7 @@ POV_LONG Task::ConsumedCPUTime() const
 void Task::Start(const boost::function0<void>& completion)
 {
     if((done == false) && (taskThread == NULL))
-        taskThread = NewBoostThread(boost::bind(&Task::TaskThread, this, completion), 1024 * 1024 * 2); // TODO - make stack size definable
+        taskThread = NewBoostThread(boost::bind(&Task::TaskThread, this, completion), POV_THREAD_STACK_SIZE);
 }
 
 void Task::RequestStop()

--- a/unix/povconfig/syspovconfigbackend.h
+++ b/unix/povconfig/syspovconfigbackend.h
@@ -11,7 +11,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
-/// Copyright 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -49,5 +49,18 @@
 // On Unix platforms, we don't do anything special at thread startup.
 #define POV_USE_DEFAULT_TASK_INITIALIZE 1
 #define POV_USE_DEFAULT_TASK_CLEANUP    1
+
+/// @note
+///     In regression testing an old scene for the 3.7.1 release found
+///     linux machines needed more stack storage than windows.
+///     See too @ref POV_THREAD_STACK_SIZE
+///
+#ifndef POV_THREAD_STACK_SIZE
+    #define POV_THREAD_STACK_SIZE (1024 * 1024 * 4)
+#else
+    #if POV_THREAD_STACK_SIZE < (1024 * 64)
+        #error "POV_THREAD_STACK_SIZE set less than 65KB or not a byte count."
+    #endif
+#endif
 
 #endif // POVRAY_UNIX_SYSPOVCONFIGBACKEND_H

--- a/unix/povconfig/syspovconfigbackend.h
+++ b/unix/povconfig/syspovconfigbackend.h
@@ -50,11 +50,8 @@
 #define POV_USE_DEFAULT_TASK_INITIALIZE 1
 #define POV_USE_DEFAULT_TASK_CLEANUP    1
 
-/// @note
-///     In regression testing an old scene for the 3.7.1 release found
-///     linux machines needed more stack storage than windows.
-///     See too @ref POV_THREAD_STACK_SIZE
-///
+// In regression testing an old scene for the 3.7.1 release found
+// linux machines needed more stack storage than windows.
 #ifndef POV_THREAD_STACK_SIZE
     #define POV_THREAD_STACK_SIZE (1024 * 1024 * 4)
 #else


### PR DESCRIPTION
Thread stack size defaulting refined. New adjustments for
64 bit compiles vs 32 bit and linux needing a larger stack size
than windows for one recent pre 371 regression.

New sub macros POV_COMPILE64 and POV_THREAD_STACK_SIZE_DEFAULTED
created in support of POV_THREAD_STACK_SIZE macro. See Doxygen
comments in code for more detail.

See newsgroup thread: 
http://news.povray.org/povray.beta-test/message/%3C589458a6%40news.povray.org%3E/#%3C589458a6%40news.povray.org%3E

A small hmm.cpp file attached which was used for test the macros and various overrides on my Ubuntu machine:  
[hmm.cpp.txt](https://github.com/POV-Ray/povray/files/753195/hmm.cpp.txt)


