### PR TITLE
Fixing thread stack size overrun crash.

### DIFF
--- a/source/backend/control/scene.cpp
+++ b/source/backend/control/scene.cpp
@@ -84,7 +84,7 @@ void Scene::StartParser(POVMS_Object& parseOptions)
 {
     // A scene can only be parsed once
     if(parserControlThread == NULL)
-        parserControlThread = Task::NewBoostThread(boost::bind(&Scene::ParserControlThread, this), 1024 * 64);
+        parserControlThread = Task::NewBoostThread(boost::bind(&Scene::ParserControlThread, this), POV_THREAD_STACK_SIZE);
     else
         return;
 

--- a/source/backend/povray.cpp
+++ b/source/backend/povray.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
-/// Copyright 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -606,7 +606,7 @@ boost::thread *povray_init(const boost::function0<void>& threadExit, POVMSAddres
         Initialize_Noise();
         pov::InitializePatternGenerators();
 
-        POV_MainThread = Task::NewBoostThread(boost::bind(&MainThreadFunction, threadExit), 1024 * 64);
+        POV_MainThread = Task::NewBoostThread(boost::bind(&MainThreadFunction, threadExit), POV_THREAD_STACK_SIZE);
 
         // we can't depend on boost::thread::yield here since under windows it is not
         // guaranteed to give up a time slice [see API docs for Sleep(0)]

--- a/source/backend/scene/view.cpp
+++ b/source/backend/scene/view.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
-/// Copyright 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -677,7 +677,7 @@ void View::StartRender(POVMS_Object& renderOptions)
     shared_ptr<ViewData::BlockIdSet> blockskiplist(new ViewData::BlockIdSet());
 
     if(renderControlThread == NULL)
-        renderControlThread = Task::NewBoostThread(boost::bind(&View::RenderControlThread, this), 1024 * 64);
+        renderControlThread = Task::NewBoostThread(boost::bind(&View::RenderControlThread, this), POV_THREAD_STACK_SIZE);
 
     viewData.qualityFlags = QualityFlags(clip(renderOptions.TryGetInt(kPOVAttrib_Quality, 9), 0, 9));
 


### PR DESCRIPTION
Fixes Dick Balaska's seg fault as reported in beta-test newsgroup on
February 12, 2017. In particular we are extending the
POV_THREAD_STACK_SIZE macro mechanism to all NewBoostThread
calls.

Ref: 
http://news.povray.org/povray.beta-test/thread/%3C58a1e32f%241%40news.povray.org%3E/

Dick's test data as zip: 
[ttcrash.zip](https://github.com/POV-Ray/povray/files/774149/ttcrash.zip)

