### PR TITLE
Relaxing Parse_Lathe point checking for versions <=3.7

### DIFF
--- a/source/parser/parser.cpp
+++ b/source/parser/parser.cpp
@@ -3010,7 +3010,11 @@ ObjectPtr Parser::Parse_Lathe()
 
               if (Points[i][X] < 0.0)
               {
-                 Error("Lathe with linear spline has a point with an x value < 0.0.");
+                 if ((sceneData->EffectiveLanguageVersion() < 371) && ((i == 0) || (i == Object->Number - 1)))
+                     Warning("Lathe with linear spline has a first or last point with an x value < 0.0\n"
+                             "Leads to artifacts and an error in #version 3.71 onward.");
+                 else
+                     Error("Lathe with linear spline has a point with an x value < 0.0.");
               }
 
               break;
@@ -3019,7 +3023,11 @@ ObjectPtr Parser::Parse_Lathe()
 
               if ((i > 0) && (Points[i][X] < 0.0))
               {
-                 Error("Lathe with quadratic spline has a point with an x value < 0.0.");
+                 if ((sceneData->EffectiveLanguageVersion() < 371) && (i == Object->Number - 1))
+                     Warning("Lathe with quadratic spline has last point with an x value < 0.0.\n"
+                             "Leads to artifacts and an error in #version 3.71 onward.");
+                 else
+                     Error("Lathe with quadratic spline has a point with an x value < 0.0.");
               }
 
               break;
@@ -3037,7 +3045,11 @@ ObjectPtr Parser::Parse_Lathe()
 
               if (((i%4 == 0) || (i%4 == 3)) && (Points[i][X] < 0.0))
               {
-                 Error("Lathe with Bezier spline has a point with an x value < 0.0.");
+                 if ((sceneData->EffectiveLanguageVersion() < 371) && ((i == 0) || (i == Object->Number - 1)))
+                     Warning("Lathe with Bezier spline has a first or last point with an x value < 0.0.\n"
+                             "Leads to artifacts and an error in #version 3.71 onward.");
+                 else
+                     Error("Lathe with Bezier spline has a point with an x value < 0.0.");
               }
               else if (!AlreadyWarned && (i%4 != 0) && (i%4 != 3) && (Points[i][X] < 0.0))
               {

--- a/source/parser/parser.cpp
+++ b/source/parser/parser.cpp
@@ -3011,7 +3011,7 @@ ObjectPtr Parser::Parse_Lathe()
               if (Points[i][X] < 0.0)
               {
                  if ((sceneData->EffectiveLanguageVersion() < 371) && ((i == 0) || (i == Object->Number - 1)))
-                     Warning("Lathe with linear spline has a first or last point with an x value < 0.0\n"
+                     Warning("Lathe with linear spline has a first or last point with an x value < 0.0.\n"
                              "Leads to artifacts and an error in #version 3.71 onward.");
                  else
                      Error("Lathe with linear spline has a point with an x value < 0.0.");


### PR DESCRIPTION
Relates to github issue #60 and merged pull request #62.

See too the newsgroup thread at:
http://news.povray.org/povray.advanced-users/thread/%3C58de4765%241%40news.povray.org%3E/

