### PR TITLE
[ci skip] Removing comment related to long gone FRAND() macro.

### DIFF
--- a/source/core/material/texture.h
+++ b/source/core/material/texture.h
@@ -61,10 +61,6 @@ struct GenericTurbulenceWarp;
 * Global preprocessor defines
 ******************************************************************************/
 
-/*
- * Macro to create random number in the [0; 1] range.
- */
-
 #define FLOOR(x)  ((x) >= 0.0 ? floor(x) : (0.0 - floor(0.0 - (x)) - 1.0))
 
 // Hash1dRTableIndex assumed values in the range 0..8191


### PR DESCRIPTION
The FRAND() macro was gone from the code on the initial import of the
code base to git/github.

There are still comments in photons.cpp which reference FRAND().
I'd argue they should be deleted too at this point, but this commit
doesn't do that bit.