### PR TITLE
Add AVXPortable and changed noise code selection

### DIFF
--- a/platform/x86/avxportable.cpp
+++ b/platform/x86/avxportable.cpp
@@ -1,0 +1,270 @@
+
+#include "syspovconfigbase.h"
+#include "avxportable.h"
+
+#include "core/material/pattern.h"
+#include "core/material/texture.h"
+
+#ifdef TRY_OPTIMIZED_NOISE_AVX_PORTABLE
+
+namespace pov
+{
+
+extern DBL RTable[];
+
+#define AVXSCURVE(a) ((a)*(a)*(3.0-2.0*(a)))
+
+#define AVXINCRSUM(m,s,x,y,z)  \
+    ((s)*(RTable[m+1] + RTable[m+2]*(x) + RTable[m+4]*(y) + RTable[m+6]*(z)))
+
+#define AVXINCRSUMP(mp,s,x,y,z) \
+    ((s)*((mp[1]) + (mp[2])*(x) + (mp[4])*(y) + (mp[6])*(z)))
+
+DBL AVXPortableNoise(const Vector3d& EPoint, int noise_generator)
+{
+	DBL x, y, z;
+	DBL *mp;
+	int tmp;
+	int ix, iy, iz;
+	int ixiy_hash, ixjy_hash, jxiy_hash, jxjy_hash;
+
+	DBL sx, sy, sz, tx, ty, tz;
+	DBL sum = 0.0;
+
+	DBL x_ix, x_jx, y_iy, y_jy, z_iz, z_jz, txty, sxty, txsy, sxsy;
+
+	// TODO FIXME - global statistics reference
+	// Stats[Calls_To_Noise]++;
+
+	if (noise_generator == kNoiseGen_Perlin)
+	{
+		// The 1.59 and 0.985 are to correct for some biasing problems with
+		// the random # generator used to create the noise tables.  Final
+		// range of values is about 5.0e-4 below 0.0 and above 1.0.  Mean
+		// value is 0.49 (ideally it would be 0.5).
+		sum = 0.5 * (1.59 * SolidNoise(EPoint) + 0.985);
+
+		// Clamp final value to 0-1 range
+		if (sum < 0.0) sum = 0.0;
+		if (sum > 1.0) sum = 1.0;
+
+		return sum;
+	}
+
+	x = EPoint[X];
+	y = EPoint[Y];
+	z = EPoint[Z];
+
+	/* its equivalent integer lattice point. */
+	/* ix = (int)x; iy = (int)y; iz = (long)z; */
+	/* JB fix for the range problem */
+	tmp = (x >= 0) ? (int)x : (int)(x - (1 - EPSILON));
+	ix = (int)((tmp - NOISE_MINX) & 0xFFF);
+	x_ix = x - tmp;
+
+	tmp = (y >= 0) ? (int)y : (int)(y - (1 - EPSILON));
+	iy = (int)((tmp - NOISE_MINY) & 0xFFF);
+	y_iy = y - tmp;
+
+	tmp = (z >= 0) ? (int)z : (int)(z - (1 - EPSILON));
+	iz = (int)((tmp - NOISE_MINZ) & 0xFFF);
+	z_iz = z - tmp;
+
+	x_jx = x_ix - 1; y_jy = y_iy - 1; z_jz = z_iz - 1;
+
+	sx = AVXSCURVE(x_ix); sy = AVXSCURVE(y_iy); sz = AVXSCURVE(z_iz);
+
+	/* the complement values of sx,sy,sz */
+	tx = 1 - sx; ty = 1 - sy; tz = 1 - sz;
+
+	/*
+	*  interpolate!
+	*/
+	txty = tx * ty;
+	sxty = sx * ty;
+	txsy = tx * sy;
+	sxsy = sx * sy;
+	ixiy_hash = Hash2d(ix, iy);
+	jxiy_hash = Hash2d(ix + 1, iy);
+	ixjy_hash = Hash2d(ix, iy + 1);
+	jxjy_hash = Hash2d(ix + 1, iy + 1);
+
+	mp = &RTable[Hash1dRTableIndex(ixiy_hash, iz)];
+	sum = AVXINCRSUMP(mp, (txty*tz), x_ix, y_iy, z_iz);
+
+	mp = &RTable[Hash1dRTableIndex(jxiy_hash, iz)];
+	sum += AVXINCRSUMP(mp, (sxty*tz), x_jx, y_iy, z_iz);
+
+	mp = &RTable[Hash1dRTableIndex(ixjy_hash, iz)];
+	sum += AVXINCRSUMP(mp, (txsy*tz), x_ix, y_jy, z_iz);
+
+	mp = &RTable[Hash1dRTableIndex(jxjy_hash, iz)];
+	sum += AVXINCRSUMP(mp, (sxsy*tz), x_jx, y_jy, z_iz);
+
+	mp = &RTable[Hash1dRTableIndex(ixiy_hash, iz + 1)];
+	sum += AVXINCRSUMP(mp, (txty*sz), x_ix, y_iy, z_jz);
+
+	mp = &RTable[Hash1dRTableIndex(jxiy_hash, iz + 1)];
+	sum += AVXINCRSUMP(mp, (sxty*sz), x_jx, y_iy, z_jz);
+
+	mp = &RTable[Hash1dRTableIndex(ixjy_hash, iz + 1)];
+	sum += AVXINCRSUMP(mp, (txsy*sz), x_ix, y_jy, z_jz);
+
+	mp = &RTable[Hash1dRTableIndex(jxjy_hash, iz + 1)];
+	sum += AVXINCRSUMP(mp, (sxsy*sz), x_jx, y_jy, z_jz);
+
+	if (noise_generator == kNoiseGen_RangeCorrected)
+	{
+		/* details of range here:
+		Min, max: -1.05242, 0.988997
+		Mean: -0.0191481, Median: -0.535493, Std Dev: 0.256828
+
+		We want to change it to as close to [0,1] as possible.
+		*/
+		sum += 1.05242;
+		sum *= 0.48985582;
+		/*sum *= 0.5;
+		sum += 0.5;*/
+
+		if (sum < 0.0)
+			sum = 0.0;
+		if (sum > 1.0)
+			sum = 1.0;
+	}
+	else
+	{
+		sum = sum + 0.5;                     /* range at this point -0.5 - 0.5... */
+
+		if (sum < 0.0)
+			sum = 0.0;
+		if (sum > 1.0)
+			sum = 1.0;
+	}
+
+	return (sum);
+}
+
+
+void AVXPortableDNoise(Vector3d& result, const Vector3d& EPoint)
+{
+	DBL x, y, z;
+	DBL *mp;
+	int tmp;
+	int ix, iy, iz;
+	int ixiy_hash, ixjy_hash, jxiy_hash, jxjy_hash;
+	DBL x_ix, x_jx, y_iy, y_jy, z_iz, z_jz;
+	DBL s;
+	DBL sx, sy, sz, tx, ty, tz;
+	DBL txty, sxty, txsy, sxsy;
+
+	// TODO FIXME - global statistics reference
+	// Stats[Calls_To_DNoise]++;
+
+	x = EPoint[X];
+	y = EPoint[Y];
+	z = EPoint[Z];
+
+	/* its equivalent integer lattice point. */
+	/*ix = (int)x; iy = (int)y; iz = (int)z;
+	x_ix = x - ix; y_iy = y - iy; z_iz = z - iz;*/
+	/* JB fix for the range problem */
+	tmp = (x >= 0) ? (int)x : (int)(x - (1 - EPSILON));
+	ix = (int)((tmp - NOISE_MINX) & 0xFFF);
+	x_ix = x - tmp;
+
+	tmp = (y >= 0) ? (int)y : (int)(y - (1 - EPSILON));
+	iy = (int)((tmp - NOISE_MINY) & 0xFFF);
+	y_iy = y - tmp;
+
+	tmp = (z >= 0) ? (int)z : (int)(z - (1 - EPSILON));
+	iz = (int)((tmp - NOISE_MINZ) & 0xFFF);
+	z_iz = z - tmp;
+
+	x_jx = x_ix - 1; y_jy = y_iy - 1; z_jz = z_iz - 1;
+
+	sx = AVXSCURVE(x_ix); sy = AVXSCURVE(y_iy); sz = AVXSCURVE(z_iz);
+
+	/* the complement values of sx,sy,sz */
+	tx = 1 - sx; ty = 1 - sy; tz = 1 - sz;
+
+	/*
+	*  interpolate!
+	*/
+	txty = tx * ty;
+	sxty = sx * ty;
+	txsy = tx * sy;
+	sxsy = sx * sy;
+	ixiy_hash = Hash2d(ix, iy);
+	jxiy_hash = Hash2d(ix + 1, iy);
+	ixjy_hash = Hash2d(ix, iy + 1);
+	jxjy_hash = Hash2d(ix + 1, iy + 1);
+
+	mp = &RTable[Hash1dRTableIndex(ixiy_hash, iz)];
+	s = txty*tz;
+	result[X] = AVXINCRSUMP(mp, s, x_ix, y_iy, z_iz);
+	mp += 8;
+	result[Y] = AVXINCRSUMP(mp, s, x_ix, y_iy, z_iz);
+	mp += 8;
+	result[Z] = AVXINCRSUMP(mp, s, x_ix, y_iy, z_iz);
+
+	mp = &RTable[Hash1dRTableIndex(jxiy_hash, iz)];
+	s = sxty*tz;
+	result[X] += AVXINCRSUMP(mp, s, x_jx, y_iy, z_iz);
+	mp += 8;
+	result[Y] += AVXINCRSUMP(mp, s, x_jx, y_iy, z_iz);
+	mp += 8;
+	result[Z] += AVXINCRSUMP(mp, s, x_jx, y_iy, z_iz);
+
+	mp = &RTable[Hash1dRTableIndex(jxjy_hash, iz)];
+	s = sxsy*tz;
+	result[X] += AVXINCRSUMP(mp, s, x_jx, y_jy, z_iz);
+	mp += 8;
+	result[Y] += AVXINCRSUMP(mp, s, x_jx, y_jy, z_iz);
+	mp += 8;
+	result[Z] += AVXINCRSUMP(mp, s, x_jx, y_jy, z_iz);
+
+	mp = &RTable[Hash1dRTableIndex(ixjy_hash, iz)];
+	s = txsy*tz;
+	result[X] += AVXINCRSUMP(mp, s, x_ix, y_jy, z_iz);
+	mp += 8;
+	result[Y] += AVXINCRSUMP(mp, s, x_ix, y_jy, z_iz);
+	mp += 8;
+	result[Z] += AVXINCRSUMP(mp, s, x_ix, y_jy, z_iz);
+
+	mp = &RTable[Hash1dRTableIndex(ixjy_hash, iz + 1)];
+	s = txsy*sz;
+	result[X] += AVXINCRSUMP(mp, s, x_ix, y_jy, z_jz);
+	mp += 8;
+	result[Y] += AVXINCRSUMP(mp, s, x_ix, y_jy, z_jz);
+	mp += 8;
+	result[Z] += AVXINCRSUMP(mp, s, x_ix, y_jy, z_jz);
+
+	mp = &RTable[Hash1dRTableIndex(jxjy_hash, iz + 1)];
+	s = sxsy*sz;
+	result[X] += AVXINCRSUMP(mp, s, x_jx, y_jy, z_jz);
+	mp += 8;
+	result[Y] += AVXINCRSUMP(mp, s, x_jx, y_jy, z_jz);
+	mp += 8;
+	result[Z] += AVXINCRSUMP(mp, s, x_jx, y_jy, z_jz);
+
+	mp = &RTable[Hash1dRTableIndex(jxiy_hash, iz + 1)];
+	s = sxty*sz;
+	result[X] += AVXINCRSUMP(mp, s, x_jx, y_iy, z_jz);
+	mp += 8;
+	result[Y] += AVXINCRSUMP(mp, s, x_jx, y_iy, z_jz);
+	mp += 8;
+	result[Z] += AVXINCRSUMP(mp, s, x_jx, y_iy, z_jz);
+
+	mp = &RTable[Hash1dRTableIndex(ixiy_hash, iz + 1)];
+	s = txty*sz;
+	result[X] += AVXINCRSUMP(mp, s, x_ix, y_iy, z_jz);
+	mp += 8;
+	result[Y] += AVXINCRSUMP(mp, s, x_ix, y_iy, z_jz);
+	mp += 8;
+	result[Z] += AVXINCRSUMP(mp, s, x_ix, y_iy, z_jz);
+}
+
+}
+
+#endif // TRY_OPTIMIZED_NOISE_AVX_PORTABLE
+

--- a/platform/x86/avxportable.h
+++ b/platform/x86/avxportable.h
@@ -1,0 +1,23 @@
+#ifndef POVRAY_AVXPORTABLENOISE_H
+#define POVRAY_AVXPORTABLENOISE_H
+
+#include "syspovconfigbase.h"
+#include "backend/frame.h"
+#include "cpuid.h"
+
+#ifdef TRY_OPTIMIZED_NOISE_AVX_PORTABLE
+
+namespace pov
+{
+
+static bool AVXPORTABLENoiseSupported() { return HaveAVX(); }
+
+DBL AVXPortableNoise(const Vector3d& EPoint, int noise_generator);
+
+void AVXPortableDNoise(Vector3d& result, const Vector3d& EPoint);
+
+}
+
+#endif // TRY_OPTIMIZED_NOISE_AVX_PORTABLE
+
+#endif // POVRAY_AVXPORTABLENOISE_H

--- a/platform/x86/cpuid.cpp
+++ b/platform/x86/cpuid.cpp
@@ -214,3 +214,16 @@ bool HaveAVX2FMA3()
     // Aggregate the information
     return osxsave && avx && fma3 && avx2 && OSSavesAVXRegisters();
 }
+
+bool isIntelCPU()
+{
+    int info[4];
+    char vendor[12];
+
+    CPUID(info, 0x0);
+    memcpy(vendor, &info[CPUID_EBX], 4);
+    memcpy(vendor + 4, &info[CPUID_EDX], 4);
+    memcpy(vendor + 8, &info[CPUID_ECX], 4);
+
+    return strncmp("GenuineIntel", vendor, 12) == 0;
+}

--- a/platform/x86/cpuid.h
+++ b/platform/x86/cpuid.h
@@ -54,4 +54,7 @@ bool HaveAVXFMA4();
 /// Test whether AVX2 and FMA3 are supported by both CPU and OS.
 bool HaveAVX2FMA3();
 
+/// Test whether it is an Intel CPU
+bool isIntelCPU();
+
 #endif // POVRAY_CPUID_H

--- a/platform/x86/optimizednoise.h
+++ b/platform/x86/optimizednoise.h
@@ -69,7 +69,7 @@ inline bool TryOptimizedNoise(NoiseFunction* pFnNoise, DNoiseFunction* pFnDNoise
     // TODO - review priority
     // NOTE - Any change to the priorization should also be reflected in `pvengine.cpp`.
 #ifdef TRY_OPTIMIZED_NOISE_AVX2FMA3
-    if (AVX2FMA3NoiseSupported())
+    if (AVX2FMA3NoiseSupported() && isIntelCPU())
     {
         AVX2FMA3NoiseInit();
         *pFnNoise  = AVX2FMA3Noise;
@@ -86,7 +86,7 @@ inline bool TryOptimizedNoise(NoiseFunction* pFnNoise, DNoiseFunction* pFnDNoise
     }
 #endif
 #ifdef TRY_OPTIMIZED_NOISE_AVX
-    if (AVXNoiseSupported())
+    if (AVXNoiseSupported() && isIntelCPU())
     {
         AVXNoiseInit();
         *pFnNoise  = AVXNoise;

--- a/platform/x86/optimizednoise.h
+++ b/platform/x86/optimizednoise.h
@@ -52,6 +52,10 @@
 #include "avxnoise.h"
 #endif
 
+#ifdef TRY_OPTIMIZED_NOISE_AVX_PORTABLE
+#include "avxportable.h"
+#endif
+
 #ifdef TRY_OPTIMIZED_NOISE
 
 namespace pov
@@ -87,6 +91,14 @@ inline bool TryOptimizedNoise(NoiseFunction* pFnNoise, DNoiseFunction* pFnDNoise
         AVXNoiseInit();
         *pFnNoise  = AVXNoise;
         *pFnDNoise = AVXDNoise;
+        return true;
+    }
+#endif
+#ifdef TRY_OPTIMIZED_NOISE_AVX_PORTABLE
+    if (AVXPORTABLENoiseSupported())
+    {
+        *pFnNoise = AVXPortableNoise;
+        *pFnDNoise = AVXPortableDNoise;
         return true;
     }
 #endif

--- a/windows/povconfig/syspovconfig_msvc.h
+++ b/windows/povconfig/syspovconfig_msvc.h
@@ -223,9 +223,10 @@
 #if _MSC_VER >= 1900
     // MSVC 2010 does not support AVX2 at all, so no need to worry about `/arch` setting.
     #define TRY_OPTIMIZED_NOISE_AVX2FMA3
+    #define TRY_OPTIMIZED_NOISE_AVX_PORTABLE
 #endif
 
-#if defined(TRY_OPTIMIZED_NOISE_AVX) || defined(TRY_OPTIMIZED_NOISE_AVXFMA4) || defined(TRY_OPTIMIZED_NOISE_AVX2FMA3)
+#if defined(TRY_OPTIMIZED_NOISE_AVX) || defined(TRY_OPTIMIZED_NOISE_AVXFMA4) || defined(TRY_OPTIMIZED_NOISE_AVX2FMA3) || defined(TRY_OPTIMIZED_NOISE_AVX_PORTABLE)
 #define TRY_OPTIMIZED_NOISE(Noise,DNoise)   TryOptimizedNoise(Noise,DNoise)
 #define OPTIMIZED_NOISE_H                   "optimizednoise.h"
 #endif

--- a/windows/pvengine.cpp
+++ b/windows/pvengine.cpp
@@ -6218,7 +6218,7 @@ int PASCAL WinMain (HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw)
   // of POVWIN, we just call the test here.
   // NOTE - The priorization should reflect `optimizednoise.h`.
 #ifdef TRY_OPTIMIZED_NOISE_AVX2FMA3
-  if (AVX2FMA3NoiseSupported())
+  if (AVX2FMA3NoiseSupported() && isIntelCPU())
   {
     buffer_message (mIDE, "AVX2/FMA3 instruction support detected: using AVX2/FMA3-optimized noise functions.\n") ;
   }
@@ -6232,7 +6232,7 @@ int PASCAL WinMain (HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw)
   else
 #endif
 #ifdef TRY_OPTIMIZED_NOISE_AVX
-  if (AVXNoiseSupported())
+  if (AVXNoiseSupported() && isIntelCPU())
   {
     buffer_message (mIDE, "AVX instruction support detected: using AVX-optimized noise functions.\n") ;
   }

--- a/windows/pvengine.cpp
+++ b/windows/pvengine.cpp
@@ -6238,6 +6238,13 @@ int PASCAL WinMain (HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw)
   }
   else
 #endif
+#ifdef TRY_OPTIMIZED_NOISE_AVX_PORTABLE
+  if (AVXPORTABLENoiseSupported())
+  {
+    buffer_message(mIDE, "AVX instruction support detected: using AVX Portable noise functions.\n");
+  }
+  else
+#endif
   {
     buffer_message (mIDE, "No enhanced instruction support detected: using compatible noise functions.\n") ;
   }

--- a/windows/pvengine.cpp
+++ b/windows/pvengine.cpp
@@ -456,6 +456,8 @@ extern HINSTANCE        hLibPovEdit ;
 
 #define MAX_INSERT_MENU_SECTIONS  8192
 
+char* selectedNoiseFunc;
+
 typedef std::vector<int> InsMenuSecList;
 
 int                     InsertMenuSection;
@@ -777,6 +779,7 @@ void PrintRenderTimes (int Finished, int NormalCompletion)
             fprintf(f, "povversion=%s\n", POV_RAY_SOURCE_VERSION) ;
             fprintf(f, "compilerversion=%s\n", POV_COMPILER_VER) ;
             fprintf(f, "platformversion=%s\n", POVRAY_PLATFORM_NAME) ;
+            fprintf(f, "noisefunctions=%s\n", selectedNoiseFunc) ;
             fclose(f);
           }
         }
@@ -6220,6 +6223,7 @@ int PASCAL WinMain (HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw)
 #ifdef TRY_OPTIMIZED_NOISE_AVX2FMA3
   if (AVX2FMA3NoiseSupported() && isIntelCPU())
   {
+    selectedNoiseFunc = "AVX2/FMA3-Intel";
     buffer_message (mIDE, "AVX2/FMA3 instruction support detected: using AVX2/FMA3-optimized noise functions.\n") ;
   }
   else
@@ -6227,6 +6231,7 @@ int PASCAL WinMain (HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw)
 #ifdef TRY_OPTIMIZED_NOISE_AVXFMA4
   if (AVXFMA4NoiseSupported())
   {
+    selectedNoiseFunc = "AVX/FMA4-AMD";
     buffer_message (mIDE, "AVX/FMA4 instruction support detected: using AVX/FMA4-optimized noise functions.\n") ;
   }
   else
@@ -6234,6 +6239,7 @@ int PASCAL WinMain (HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw)
 #ifdef TRY_OPTIMIZED_NOISE_AVX
   if (AVXNoiseSupported() && isIntelCPU())
   {
+    selectedNoiseFunc = "AVX-Intel";
     buffer_message (mIDE, "AVX instruction support detected: using AVX-optimized noise functions.\n") ;
   }
   else
@@ -6241,11 +6247,13 @@ int PASCAL WinMain (HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw)
 #ifdef TRY_OPTIMIZED_NOISE_AVX_PORTABLE
   if (AVXPORTABLENoiseSupported())
   {
+    selectedNoiseFunc = "AVX-Portable";
     buffer_message(mIDE, "AVX instruction support detected: using AVX Portable noise functions.\n");
   }
   else
 #endif
   {
+    selectedNoiseFunc = "Portable";
     buffer_message (mIDE, "No enhanced instruction support detected: using compatible noise functions.\n") ;
   }
   buffer_message (mDivider, "\n") ;

--- a/windows/vs2015/povplatform.vcxproj
+++ b/windows/vs2015/povplatform.vcxproj
@@ -382,6 +382,9 @@
     <ClCompile Include="..\..\platform\x86\avx2fma3noise.cpp" />
     <ClCompile Include="..\..\platform\x86\avxfma4noise.cpp" />
     <ClCompile Include="..\..\platform\x86\avxnoise.cpp" />
+    <ClCompile Include="..\..\platform\x86\avxportable.cpp">
+      <EnableEnhancedInstructionSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+    </ClCompile>
     <ClCompile Include="..\..\platform\x86\cpuid.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -393,6 +396,7 @@
     <ClInclude Include="..\..\platform\x86\avx2fma3noise.h" />
     <ClInclude Include="..\..\platform\x86\avxfma4noise.h" />
     <ClInclude Include="..\..\platform\x86\avxnoise.h" />
+    <ClInclude Include="..\..\platform\x86\avxportable.h" />
     <ClInclude Include="..\..\platform\x86\cpuid.h" />
     <ClInclude Include="..\..\platform\x86\optimizednoise.h" />
   </ItemGroup>

--- a/windows/vs2015/povplatform.vcxproj.filters
+++ b/windows/vs2015/povplatform.vcxproj.filters
@@ -49,6 +49,9 @@
     <ClCompile Include="..\..\platform\x86\avxnoise.cpp">
       <Filter>Platform Source\x86</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\platform\x86\avxportable.cpp">
+      <Filter>Platform Source\x86</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\platform\x86\avxfma4noise.h">
@@ -79,6 +82,9 @@
       <Filter>Platform Headers\x86</Filter>
     </ClInclude>
     <ClInclude Include="..\..\platform\x86\avxnoise.h">
+      <Filter>Platform Headers\x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\platform\x86\avxportable.h">
       <Filter>Platform Headers\x86</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
1) Added new noise implementation "AVXPortable" which is simply PortableNoise compiled separately with compiler AVX flags.

2) Changed the noise code selection based on CPU vendor because the existing AVX and AVX2FMA3 implementations lower performance on non-Intel CPUs compared to the new AVXPortable or existing portable (non-AVX) noise functions.