### PR TITLE
Improving AA performance for non MSVC compilers.

### DIFF
--- a/source/backend/render/tracetask.cpp
+++ b/source/backend/render/tracetask.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
-/// Copyright 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -216,8 +216,7 @@ RGBTColour& TraceTask::SubdivisionBuffer::operator()(size_t x, size_t y)
 
 void TraceTask::SubdivisionBuffer::Clear()
 {
-    for(vector<bool>::iterator i(sampled.begin()); i != sampled.end(); i++)
-        *i = false;
+    sampled.assign(sampled.size(), false);
 }
 
 TraceTask::TraceTask(ViewData *vd, unsigned int tm, DBL js, DBL aat, unsigned int aad, pov_base::GammaCurvePtr& aag, unsigned int ps, bool psc, bool final, bool hr) :


### PR DESCRIPTION
Web searches turned up evidence the existing code has the best
performance for Microsoft Visual C++, but performance is awful for g++
and clang compared to sampled.assign method.

g++ (5.4.0) +a0.05 +am2 +r5 +w1800 +H1200 complete render
(threads==cores) is 23% slower with iterator method.

clang (3.8.0-2) with AA above is 28% slower using iterator.