### PR TITLE
Improving performance of gatherPhotonsRec function.

### DIFF
--- a/source/core/lighting/photons.cpp
+++ b/source/core/lighting/photons.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
-/// Copyright 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -2057,12 +2057,12 @@ void PhotonMap::setGatherOptions(ScenePhotonSettings &photonSettings, int mediaM
 
   Preconditions:
 
-  static DBL size_sq_s;   - maximum radius given squared
-  static DBL Size_s;      - radius
-  static DBL dmax_s;      - square of radius used so far
-  static int TargetNum_s; - target number
-  static DBL *pt_s;       - center point
-  static numfound_s;      - number of photons in priority queue
+  DBL size_sq_s;   - maximum radius given squared
+  DBL Size_s;      - radius
+  DBL dmax_s;      - square of radius used so far
+  int TargetNum_s; - target number
+  Vector3d *pt_s;  - center point
+  numfound_s;      - number of photons in priority queue
 
   these must be allocated:
     renderer->sceneData->photonSettings.photonGatherList - array of photons in priority queue
@@ -2280,18 +2280,21 @@ void PhotonGatherer::gatherPhotonsRec(int start, int end)
 
     // check this photon
 
-    // find distance from pt
-    ptToPhoton = - (*pt_s) + Vector3d(photon->Loc);
-    // all distances are squared
-    dx = ptToPhoton[X]*ptToPhoton[X];
-    dy = ptToPhoton[Y]*ptToPhoton[Y];
-    dz = ptToPhoton[Z]*ptToPhoton[Z];
+    // find distance in DimToUse from pt
+    d = photon->Loc[DimToUse] - (*pt_s)[DimToUse];
+    d *= d;
 
-    if (!(  ((dx>dmax_s) && ((DimToUse)==X)) ||
-            ((dy>dmax_s) && ((DimToUse)==Y)) ||
-            ((dz>dmax_s) && ((DimToUse)==Z)) ))
+    if (d<dmax_s)
     {
-        // it fits manhatten distance - maybe we can use this photon
+        // it fits manhatten, DimToUse distance - maybe we can use this photon
+
+        dx = photon->Loc[X] - (*pt_s)[X];
+        dy = photon->Loc[Y] - (*pt_s)[Y];
+        dz = photon->Loc[Z] - (*pt_s)[Z];
+        ptToPhoton = Vector3d(dx,dy,dz);
+        dx *= dx;
+        dy *= dy;
+        dz *= dz;
 
         // find euclidian distance (squared)
         d = dx + dy + dz;


### PR DESCRIPTION
While gains vary, anything run with photons was 0.5-2% faster. Scenes like optics.pov show the most gains at 10-12% faster.

-----------
Some data for performance/gatherPhotonsRec  (threads==cores)

```
balcony.pov (no radiosity) 
+W1200 +H900 +A0.1 +am2 +r3 +wt2 -D -P
-----------
Number of photons shot:           21470
Surface photons stored:           26871
Gather function called:        10218658
 96.38user 0.05system 0:49.55elapsed
 95.65user 0.05system 0:49.15elapsed
 95.77user 0.03system 0:49.25elapsed
 95.93

Number of photons shot:           21470
Surface photons stored:           26871
Gather function called:        10218074(1)
 95.15user 0.07system 0:48.99elapsed
 94.52user 0.06system 0:48.62elapsed
 94.87user 0.06system 0:48.75elapsed
 94.85                               -1.13%

(1) - isosurface accuracy with slightly different FP math
optimization (linux -ffast-math ?) results is a few pixels being
different when no AA. With AA no difference.


optics.pov  
+W1200 +H900 +A0.1 +am2 +r3 +wt2 -D -P
-----------
 Number of photons shot:    22441
 Surface photons stored:     5441
 Media photons stored:     100031
 Gather function called: 16099025
 427.09user 0.12system 3:34.85elapsed
 426.78user 0.08system 3:34.57elapsed
 426.94

 Number of photons shot:    22441
 Surface photons stored:     5441
 Media photons stored:     100031
 Gather function called: 16099025
 ---
 374.84user 0.10system 3:08.68elapsed
 374.54user 0.10system 3:08.62elapsed
 374.69                               -12.24%


-----------
diffuse_back.pov  
-w640 -h480 +wt2 +A0.1 +am2 +r3 -D -P
-----------------------------
4683.43user 1.42system 39:04.94elapsed
4614.93user 1.50system 38:31.72elapsed -1.46%
```
