### PR TITLE
Restoring 3.6 user bounding control.

### DIFF
--- a/source/core/render/trace.cpp
+++ b/source/core/render/trace.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
-/// Copyright 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -339,12 +339,13 @@ bool Trace::FindIntersection(ObjectPtr object, Intersection& isect, const Ray& r
         BBoxVector3d invdir;
         BBoxDirection variant;
 
-        Vector3d tmp(1.0 / ray.GetDirection()[X], 1.0 / ray.GetDirection()[Y], 1.0 /ray.GetDirection()[Z]);
+        Vector3d tmp(1.0 / ray.GetDirection()[X], 1.0 / ray.GetDirection()[Y], 1.0 / ray.GetDirection()[Z]);
         origin = BBoxVector3d(ray.Origin);
         invdir = BBoxVector3d(tmp);
         variant = (BBoxDirection)((int(invdir[X] < 0.0) << 2) | (int(invdir[Y] < 0.0) << 1) | int(invdir[Z] < 0.0));
 
-        if(object->Intersect_BBox(variant, origin, invdir, closest) == false)
+        // Note: At leaf when called. Suspect not strictly needed. However, without slightly slower in performance.
+        if((object->Intersect_BBox(variant, origin, invdir, closest) == false) && (sceneData->boundingMethod != 0))
             return false;
 
         if(object->Bound.empty() == false)
@@ -392,12 +393,13 @@ bool Trace::FindIntersection(ObjectPtr object, Intersection& isect, const Ray& r
         BBoxVector3d invdir;
         BBoxDirection variant;
 
-        Vector3d tmp(1.0 / ray.GetDirection()[X], 1.0 / ray.GetDirection()[Y], 1.0 /ray.GetDirection()[Z]);
+        Vector3d tmp(1.0 / ray.GetDirection()[X], 1.0 / ray.GetDirection()[Y], 1.0 / ray.GetDirection()[Z]);
         origin = BBoxVector3d(ray.Origin);
         invdir = BBoxVector3d(tmp);
         variant = (BBoxDirection)((int(invdir[X] < 0.0) << 2) | (int(invdir[Y] < 0.0) << 1) | int(invdir[Z] < 0.0));
 
-        if(object->Intersect_BBox(variant, origin, invdir, closest) == false)
+        // Note: At leaf when called. Suspect not strictly needed. However, without slightly slower in performance.
+        if((object->Intersect_BBox(variant, origin, invdir, closest) == false) && (sceneData->boundingMethod != 0))
             return false;
 
         if(object->Bound.empty() == false)

--- a/source/core/render/trace.cpp
+++ b/source/core/render/trace.cpp
@@ -331,6 +331,20 @@ bool Trace::FindIntersection(Intersection& bestisect, const Ray& ray, const RayO
     return false;
 }
 
+
+// The following Trace::FindIntersection functions are never called on
+// bounding hierarchy leaves; rather only called when not traversing the
+// bounding hierarchy:  Either to compute the intersections with infinite
+// objects if they're not already accounted for by the bounding hierarchy
+// chosen, or because bounding is disabled entirely, or because only the
+// intersections with one particular object are of interest (e.g.  the
+// projected_through object of a light source, but also the shadow caching
+// mechanism).
+//
+// In the former two cases it wouldn't be necessary to perform the bounding
+// box test, but in the latter case it is indispensable for good
+// performance. Hence, the initial bounding test.
+
 bool Trace::FindIntersection(ObjectPtr object, Intersection& isect, const Ray& ray, double closest)
 {
     if(object != NULL)
@@ -344,8 +358,7 @@ bool Trace::FindIntersection(ObjectPtr object, Intersection& isect, const Ray& r
         invdir = BBoxVector3d(tmp);
         variant = (BBoxDirection)((int(invdir[X] < 0.0) << 2) | (int(invdir[Y] < 0.0) << 1) | int(invdir[Z] < 0.0));
 
-        // Note: At leaf when called. Suspect not strictly needed. However, without slightly slower in performance.
-        if((object->Intersect_BBox(variant, origin, invdir, closest) == false) && (sceneData->boundingMethod != 0))
+        if((sceneData->boundingMethod != 0) && (object->Intersect_BBox(variant, origin, invdir, closest) == false))
             return false;
 
         if(object->Bound.empty() == false)
@@ -398,8 +411,7 @@ bool Trace::FindIntersection(ObjectPtr object, Intersection& isect, const Ray& r
         invdir = BBoxVector3d(tmp);
         variant = (BBoxDirection)((int(invdir[X] < 0.0) << 2) | (int(invdir[Y] < 0.0) << 1) | int(invdir[Z] < 0.0));
 
-        // Note: At leaf when called. Suspect not strictly needed. However, without slightly slower in performance.
-        if((object->Intersect_BBox(variant, origin, invdir, closest) == false) && (sceneData->boundingMethod != 0))
+        if((sceneData->boundingMethod != 0) && (object->Intersect_BBox(variant, origin, invdir, closest) == false))
             return false;
 
         if(object->Bound.empty() == false)


### PR DESCRIPTION
The ini options Bounding=off, Bounding_Threshold=n and
the command line options -MB, -MBn turning automatic
bounding off will again function.

This commit fixes the remaining bounding control issues reported in issue #59.

The following test scene when run with -mb will now render the badly auto-bounded cubic sphere_sweep correctly.

```
#version 3.7;

// povray -mb <this_pov_scene_filename>
//
// Note: This test depends on the sphere_sweep generating
// bad bounding so it only renders correctly if POV-Ray
// bounding is completely off.
//

global_settings { assumed_gamma 1 }
camera {
    location <0.0, 1.5, -8.5>
    look_at <0.0, 1.5, 0.0>
    angle 29
}
light_source { <-4.562, 10.625, -7.902>, rgb 1 }

#declare R = 0.07;

sphere_sweep {
    cubic_spline 6,
    <1, -1>, R,
    <-1, -1>, R,
    <-1, 1>, R,
    <1, 1>, R,
    <1, -1>, R,
    <-1, -1>, R
    pigment { red 1 }
    translate <0,1.5,0>
}

sphere { <0.0, 1.9, 0.0>, 0.05 pigment { green 1 } }
sphere { <0.0, 1.7, 0.0>, 0.05 pigment { green 1 } }
sphere { <0.0, 1.5, 0.0>, 0.05 pigment { green 1 } }
sphere { <0.0, 1.3, 0.0>, 0.05 pigment { green 1 } }
sphere { <0.0, 1.1, 0.0>, 0.05 pigment { green 1 } }
```
