### PR TITLE
Fix compatibility with GCC 6.x

### DIFF
--- a/source/backend/parser/parsestr.cpp
+++ b/source/backend/parser/parsestr.cpp
@@ -529,7 +529,7 @@ UCS2 *Parser::Parse_Datetime(bool pathname)
 			throw;
 		vlen = 0;
 	}
-	if ((vlen == PARSE_NOW_VAL_LENGTH)) // on error: max for libc 4.4.1 & before
+	if (vlen == PARSE_NOW_VAL_LENGTH) // on error: max for libc 4.4.1 & before
 		vlen = 0; // return an empty string on error (content of val[] is undefined)
 	val[vlen]='\0'; // whatever, that operation is now safe (and superflous except for error)
 

--- a/source/backend/parser/parstxtr.cpp
+++ b/source/backend/parser/parstxtr.cpp
@@ -2114,7 +2114,7 @@ void Parser::Parse_Pattern (TPATTERN *New, int TPat_Type)
 		Error("Patterned texture must have texture_map.");
 	}
 
-	if ((New->Type==PAVEMENT_PATTERN))
+	if (New->Type==PAVEMENT_PATTERN)
 	{
 		const int valid6[]={1,1,3,7,22};
 		const int valid4[]={1,1,2,5,12,35};

--- a/source/backend/pattern/pattern.cpp
+++ b/source/backend/pattern/pattern.cpp
@@ -8436,7 +8436,7 @@ unsigned long int NewHash(long int tvx, long int tvy, long int tvz)
 	tvz *= 83492791L;
 
 	r = tvx ^ tvy ^ tvz;
-	seed = abs(r);
+	seed = std::abs(r);
 	if (tvx<0) seed += LONG_MAX/2;
 	if (tvy<0) seed += LONG_MAX/4;
 	if (tvz<0) seed += LONG_MAX/8;

--- a/source/backend/render/trace.cpp
+++ b/source/backend/render/trace.cpp
@@ -2437,8 +2437,8 @@ void Trace::ComputeIridColour(const FINISH *finish, const Vector3d& lightsource,
 	bwl = sceneData->iridWavelengths.blue();
 
 	// NOTE: Shouldn't we compute Cos_Angle_Of_Incidence just once?
-	cos_angle_of_incidence_light = abs(dot(layer_normal, lightsource));
-	cos_angle_of_incidence_eye   = abs(dot(layer_normal, eye));
+	cos_angle_of_incidence_light = std::abs(dot(layer_normal, lightsource));
+	cos_angle_of_incidence_eye   = std::abs(dot(layer_normal, eye));
 
 	// Calculate phase offset.
 	interference = 2.0 * M_PI * film_thickness * (cos_angle_of_incidence_light + cos_angle_of_incidence_eye);
@@ -3274,7 +3274,7 @@ void Trace::ComputeDiffuseSamplePoint(const Vector3d& basePoint, Intersection& i
 
 		Vector3d vDelta = Vector3d(in.IPoint) - basePoint;
 		double dist = vDelta.length();
-		double cos_phi = abs(dot(vDelta / dist, Vector3d(in.INormal)));
+		double cos_phi = std::abs(dot(vDelta / dist, Vector3d(in.INormal)));
 		if (cos_phi < 0)
 		{
 			VScaleEq(in.INormal, -1.0);

--- a/source/base/image/hdr.cpp
+++ b/source/base/image/hdr.cpp
@@ -144,7 +144,7 @@ void ReadOldLine(unsigned char *scanline, int width, IStream *file)
 
 		// NB EOF won't be set at this point even if the last read obtained the
 		// final byte in the file (we need to read another byte for that to happen).
-		if(*file == false)
+		if(!*file)
 			throw POV_EXCEPTION(kFileDataErr, "Invalid HDR file (unexpected EOF)");
 
 		if(file->Read_Byte(b).eof())
@@ -199,7 +199,7 @@ Image *Read(IStream *file, const Image::ReadOptions& options)
 
 	while(*file)
 	{
-		if((file->getline(line, sizeof(line)) == false) || (line[0] == '-') || (line[0] == '+'))
+		if(!file->getline(line, sizeof(line)) || (line[0] == '-') || (line[0] == '+'))
 			break;
 
 		// TODO: what do we do with exposure?
@@ -233,7 +233,7 @@ Image *Read(IStream *file, const Image::ReadOptions& options)
 			continue;
 		}
 
-		if(file->Read_Byte(b) == false)
+		if(!file->Read_Byte(b))
 			throw POV_EXCEPTION(kFileDataErr, "Incomplete HDR file");
 
 		if(b != 2)
@@ -248,7 +248,7 @@ Image *Read(IStream *file, const Image::ReadOptions& options)
 		scanline[1] = file->Read_Byte();
 		scanline[2] = file->Read_Byte();
 
-		if(file->Read_Byte(b) == false)
+		if(!file->Read_Byte(b))
 			throw POV_EXCEPTION(kFileDataErr, "Incomplete or invalid HDR file");
 
 		if((scanline[1] != 2) || ((scanline[2] & 128) != 0))
@@ -268,7 +268,7 @@ Image *Read(IStream *file, const Image::ReadOptions& options)
 		{
 			for(int j = 0; j < width; )
 			{
-				if(file->Read_Byte(b) == false)
+				if(!file->Read_Byte(b))
 					throw POV_EXCEPTION(kFileDataErr, "Invalid HDR file (unexpected EOF)");
 
 				if(b > 128)
@@ -276,7 +276,7 @@ Image *Read(IStream *file, const Image::ReadOptions& options)
 					// run
 					b &= 127;
 
-					if(file->Read_Byte(val) == false)
+					if(!file->Read_Byte(val))
 						throw POV_EXCEPTION(kFileDataErr, "Invalid HDR file (unexpected EOF)");
 
 					while(b--)
@@ -286,7 +286,7 @@ Image *Read(IStream *file, const Image::ReadOptions& options)
 				{
 					while(b--)
 					{
-						if(file->Read_Byte(val) == false)
+						if(!file->Read_Byte(val))
 							throw POV_EXCEPTION(kFileDataErr, "Invalid HDR file (unexpected EOF)");
 
 						scanline[j++ * 4 + i] = (unsigned char) val;
@@ -338,7 +338,7 @@ void Write(OStream *file, const Image *image, const Image::WriteOptions& options
 			{
 				GetRGBE(rgbe, image, col, row, gamma, dither);
 
-				if(file->write(&rgbe, sizeof(RGBE)) == false)
+				if(!file->write(&rgbe, sizeof(RGBE)))
 					throw POV_EXCEPTION(kFileDataErr, "Failed to write data to HDR file");
 			}
 		}
@@ -383,7 +383,7 @@ void Write(OStream *file, const Image *image, const Image::WriteOptions& options
 								// short run
 								file->Write_Byte(128 + beg - col);
 
-								if(file->Write_Byte(scanline[col][i]) == false)
+								if(!file->Write_Byte(scanline[col][i]))
 									throw POV_EXCEPTION(kFileDataErr, "Failed to write data to HDR file");
 
 								col = beg;
@@ -401,7 +401,7 @@ void Write(OStream *file, const Image *image, const Image::WriteOptions& options
 
 						while(c2--)
 						{
-							if(file->Write_Byte(scanline[col++][i]) == false)
+							if(!file->Write_Byte(scanline[col++][i]))
 								throw POV_EXCEPTION(kFileDataErr, "Failed to write data to HDR file");
 						}
 					}
@@ -410,7 +410,7 @@ void Write(OStream *file, const Image *image, const Image::WriteOptions& options
 						// write run
 						file->Write_Byte(128 + cnt);
 
-						if(file->Write_Byte(scanline[beg][i]) == false)
+						if(!file->Write_Byte(scanline[beg][i]))
 							throw POV_EXCEPTION(kFileDataErr, "Failed to write data to HDR file");
 					}
 					else

--- a/source/base/povmscpp.h
+++ b/source/base/povmscpp.h
@@ -292,11 +292,13 @@ class POVMS_MessageReceiver
 		class HandlerOO
 		{
 			public:
+				virtual ~HandlerOO() {}
 				virtual void Call(POVMS_Message&, POVMS_Message&, int) = 0;
 		};
 		class Handler
 		{
 			public:
+				virtual ~Handler() {}
 				virtual void Call(POVMSObjectPtr, POVMSObjectPtr, int) = 0;
 		};
 	protected:

--- a/source/frontend/renderfrontend.cpp
+++ b/source/frontend/renderfrontend.cpp
@@ -614,7 +614,7 @@ void RenderFrontendBase::NewBackup(POVMS_Object& ropts, ViewData& vd, const Path
 			throw POV_EXCEPTION(kCannotOpenFileErr, "Cannot create render state output file.");
 		memcpy(hdr.sig, RENDER_STATE_SIG, sizeof(hdr.sig));
 		memcpy(hdr.ver, RENDER_STATE_VER, sizeof(hdr.ver));
-		if(vd.imageBackup->write(&hdr, sizeof(hdr)) == false)
+		if(!vd.imageBackup->write(&hdr, sizeof(hdr)))
 			throw POV_EXCEPTION(kFileDataErr, "Cannot write header to render state output file.");
 		vd.imageBackup->flush();
 
@@ -667,7 +667,7 @@ void RenderFrontendBase::ContinueBackup(POVMS_Object& ropts, ViewData& vd, ViewI
 			POV_LONG end = inbuffer->tellg();
 			inbuffer->seekg (0, IOBase::seek_set);
 
-			if (inbuffer->read (&hdr, sizeof (hdr)) == false)
+			if (!inbuffer->read (&hdr, sizeof (hdr)))
 				throw POV_EXCEPTION(kFileDataErr, "Cannot read header from render state file.");
 			if (memcmp (hdr.sig, RENDER_STATE_SIG, sizeof (hdr.sig)) != 0)
 				throw POV_EXCEPTION(kFileDataErr, "Render state file header appears to be invalid.");

--- a/source/frontend/shelloutprocessing.cpp
+++ b/source/frontend/shelloutprocessing.cpp
@@ -198,7 +198,7 @@ bool ShelloutProcessing::ExtractCommand(const string& src, string& command, stri
 	command.clear();
 	parameters.clear();
 	string str = boost::trim_copy(src);
-	for (s = str.c_str(); *s; *s++)
+	for (s = str.c_str(); *s; s++)
 	{
 		if (hadEscape)
 		{

--- a/source/frontend/simplefrontend.h
+++ b/source/frontend/simplefrontend.h
@@ -266,11 +266,11 @@ State SimpleFrontend<PARSER_MH, FILE_MH, RENDER_MH, IMAGE_MH>::Process()
 				if(animationProcessing != NULL)
 				{
 					options = animationProcessing->GetFrameRenderOptions();
-					if (imageProcessing != NULL);
+					if (imageProcessing != NULL)
 						options.SetUCS2String(kPOVAttrib_OutputFile, imageProcessing->GetOutputFilename(options, animationProcessing->GetFrameNumber(), animationProcessing->GetFrameNumberDigits()).c_str());
 				}
 				else
-					if (imageProcessing != NULL);
+					if (imageProcessing != NULL)
 						options.SetUCS2String(kPOVAttrib_OutputFile, imageProcessing->GetOutputFilename(options, 0, 0).c_str());
 			}
 			catch(pov_base::Exception&)


### PR DESCRIPTION
Minor code modifications to eliminate compile errors in `base/image/hdr.cpp` reported for GNU g++ 6.3.1.

Also cleaned up some clang 4.2 compiler warnings along the way.