### PR TITLE
Make build reproducible

### DIFF
--- a/unix/prebuild.sh
+++ b/unix/prebuild.sh
@@ -778,7 +778,7 @@ case "$1" in
   ;;
 
   *)
-  files=`find $dir -name "*.cpp" -or -name "*.h" | sed s,"$dir/",,g`
+  files=`find $dir -name "*.cpp" -or -name "*.h" | sed s,"$dir/",,g | sort`
 
   echo "Create $makefile.am"
   cat Makefile.header > $makefile.am
@@ -1310,7 +1310,7 @@ case "$1" in
 
   *)
   # includes the vfe/unix/ files to avoid circular dependencies when linking
-  files=`find $dir $dir/unix -maxdepth 1 -name \*.cpp -or -name \*.h | sed s,"$dir/",,g`
+  files=`find $dir $dir/unix -maxdepth 1 -name \*.cpp -or -name \*.h | sed s,"$dir/",,g | sort`
 
   echo "Create $makefile.am"
   cat Makefile.header > $makefile.am


### PR DESCRIPTION
when linking binaries with g++, order of input files
influences ordering of functions in the output

See https://reproducible-builds.org/ for why this matters.