### PR TITLE
Fix crash in radiosity.cpp related to mosaic preview.

### DIFF
--- a/source/backend/lighting/radiosity.cpp
+++ b/source/backend/lighting/radiosity.cpp
@@ -318,10 +318,12 @@ void RadiosityFunction::ResetTopLevelStats()
 
 void RadiosityFunction::BeforeTile(int id, unsigned int pts)
 {
+	/*
 	if (isFinalTrace)
 		assert( pts == FINAL_TRACE );
 	else
 		assert( (pts >= PRETRACE_FIRST) && (pts <= PRETRACE_MAX) );
+	*/
 
 	// different pretrace step than last tile
 	if (pts != pretraceStep)


### PR DESCRIPTION
This pull request duplicates an old fix already applied to the 3.7.1 branch, fixing a crash in `radiosity.cpp` when mosaic pretrace is enabled (originally tracked on FlySpray as FS313 and recently reported again on the `povray.bugreports` newsgroup).