### PR TITLE
Default ambient for 3.8 and above

### DIFF
--- a/source/core/material/texture.cpp
+++ b/source/core/material/texture.cpp
@@ -212,6 +212,10 @@ void Transform_Textures(TEXTURE *Textures, const TRANSFORM *Trans)
 *   6/27/98  MBP  Added initializers for reflection blur
 *   8/27/98  MBP  Added initializers for angle-based reflectivity
 *
+* NOTES
+*   since 3.8, the default ambient might be overriden to 0.0 when the first statement
+*   is a #version with value 3.8 or greater or when such version is set explicitly in command line or ini file
+*
 ******************************************************************************/
 
 FINISH *Create_Finish()

--- a/source/parser/parser.cpp
+++ b/source/parser/parser.cpp
@@ -184,6 +184,12 @@ void Parser::Run()
         Default_Texture->Pigment = Create_Pigment();
         Default_Texture->Tnormal = NULL;
         Default_Texture->Finish  = Create_Finish();
+        // [JG] the version has been *explictly* set in the ini or command line,
+        // override the default ambient (rgb 0.1) (in Create_Finish) for 0.0
+        if ((sceneData->languageVersionSet)&&(sceneData->languageVersion >= 380))
+        {
+            Default_Texture->Finish->Ambient.Clear();
+        }
 
         Not_In_Default = true;
         Ok_To_Declare = true;

--- a/source/parser/parser_tokenizer.cpp
+++ b/source/parser/parser_tokenizer.cpp
@@ -2430,7 +2430,12 @@ void Parser::Parse_Directive(int After_Hash)
                                 if (Include_File_Index == 0)
                                     Error("As of POV-Ray 3.7, the '#version' directive must be the first non-comment "
                                           "statement in the scene file. If your scene will adapt to whatever version "
-                                          "is un use dynamically, start your scene with '#version version'.");
+                                          "is in use dynamically, start your scene with '#version version'.");
+                            }
+                            else if ((!sceneData->languageVersionSet)&&(sceneData->languageVersion >= 380))
+                            {// [JG] first item, not languageVersionLate : override the default ambient (rgb 0.1) (in Create_Finish) for 0.0
+                             // Do not bother to create a copy, it has not been used yet
+                                Default_Texture->Finish->Ambient.Clear();
                             }
 
                             // NB: This must be set _after_ parsing the value, in order for the `#version version`


### PR DESCRIPTION
When version is set as the first statement of the scene or via option, and the version is 3.8 or more, the default ambient is 0 instead of the previous 0.1 which has problem with the gamma handling.