### PR TITLE
GetTerminalWidth() into a more proper module

### DIFF
--- a/platform/unix/syspovconsole.cpp
+++ b/platform/unix/syspovconsole.cpp
@@ -1,0 +1,69 @@
+//******************************************************************************
+///
+/// @file platform/unix/syspovconsole.cpp
+///
+/// Unix-specific implementation of the @ref pov_base::GetTerminalWidth() function
+///
+/// @copyright
+/// @parblock
+///
+/// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
+/// Copyright 1991-2016 Persistence of Vision Raytracer Pty. Ltd.
+///
+/// POV-Ray is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU Affero General Public License as
+/// published by the Free Software Foundation, either version 3 of the
+/// License, or (at your option) any later version.
+///
+/// POV-Ray is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU Affero General Public License for more details.
+///
+/// You should have received a copy of the GNU Affero General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+///
+/// ----------------------------------------------------------------------------
+///
+/// POV-Ray is based on the popular DKB raytracer version 2.12.
+/// DKBTrace was originally written by David K. Buck.
+/// DKBTrace Ver 2.0-2.12 were written by David K. Buck & Aaron A. Collins.
+///
+/// @endparblock
+///
+//******************************************************************************
+
+#include "syspovconsole.h"
+
+#if defined(HAVE_SYS_IOCTL_H)
+#include <sys/ioctl.h>
+#endif
+#if !defined(GWINSZ_IN_SYS_IOCTL)
+#include <termios.h>
+#endif
+
+// this must be the last file included
+#include "base/povdebug.h"
+
+namespace pov_base
+{
+
+//******************************************************************************
+
+unsigned int GetTerminalWidth()
+{
+#if defined(TIOCGWINSZ) && defined(HAVE_IOCTL)
+    struct winsize w;
+
+    // the ioctl call returns non-zero in case of errors (terminal not ready or
+    // function non supported)
+    // further, some systems use to return zero even though the call wasn't
+    // successful, and signal the error condition by filling the column number
+    // with zero
+    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == 0 && w.ws_col != 0)
+        return (unsigned int)w.ws_col;
+#endif
+    return 80;
+}
+
+}

--- a/platform/unix/syspovconsole.h
+++ b/platform/unix/syspovconsole.h
@@ -1,0 +1,57 @@
+//******************************************************************************
+///
+/// @file platform/unix/syspovconsole.h
+///
+/// Unix-specific declaration of the @ref pov_base::GetTerminalWidth() function
+///
+/// @copyright
+/// @parblock
+///
+/// Persistence of Vision Ray Tracer ('POV-Ray') version 3.7.
+/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+///
+/// POV-Ray is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU Affero General Public License as
+/// published by the Free Software Foundation, either version 3 of the
+/// License, or (at your option) any later version.
+///
+/// POV-Ray is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU Affero General Public License for more details.
+///
+/// You should have received a copy of the GNU Affero General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+///
+/// ----------------------------------------------------------------------------
+///
+/// POV-Ray is based on the popular DKB raytracer version 2.12.
+/// DKBTrace was originally written by David K. Buck.
+/// DKBTrace Ver 2.0-2.12 were written by David K. Buck & Aaron A. Collins.
+///
+/// @endparblock
+///
+//******************************************************************************
+
+#ifndef POVRAY_UNIX_SYSPOVCONSOLE_H
+#define POVRAY_UNIX_SYSPOVCONSOLE_H
+
+#include "base/configbase.h"
+
+namespace pov_base
+{
+
+/// Detect the terminal width.
+///
+/// This Unix-specific function implements the specific (virtual) terminal
+/// calls needed to know the width of the current console. This is required by
+/// POV-Ray since some diagnostic routines use to wrap text messages at
+/// terminal border in a clean way and not let the terminal cut words at any
+/// position.
+///
+
+unsigned int GetTerminalWidth(void);
+
+}
+
+#endif // POVRAY_UNIX_SYSPOVCONSOLE_H

--- a/vfe/vfesession.cpp
+++ b/vfe/vfesession.cpp
@@ -42,6 +42,7 @@
 
 #include "vfe.h"
 #include "backend/povray.h"
+#include "syspovconsole.h"
 
 static POVMSContext POVMS_Output_Context = NULL;
 
@@ -74,7 +75,7 @@ vfeSession::vfeSession(int id)
   m_MaxGenericMessages = -1;
   m_MaxConsoleMessages = -1;
   m_OptimizeForConsoleOutput = true;
-  m_ConsoleWidth = 80;
+  m_ConsoleWidth = pov_base::GetTerminalWidth();
   m_RequestFlag = rqNoRequest;
   m_RequestResult = 0;
   m_StartTime = 0;


### PR DESCRIPTION
Following your suggestions, I think now the original idea is pretty realized.
Only a question remains for me, and it is about that `vfesession.cpp`, does it only get built under unix-like OSs, does it?
