### PR TITLE
[ci skip] Adding /unix/config/ar-lib to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,7 @@ $RECYCLE.BIN/
 /source/Makefile.in
 /unix/Makefile.am
 /unix/Makefile.in
+/unix/config/ar-lib
 /unix/config/compile
 /unix/config/config.guess
 /unix/config/config.sub


### PR DESCRIPTION
Notes. The new 'ar-lib' file link into the automake install showed up when I updated to the latest 3.8, but might be due automake itself or automake as now called. The ar-lib program is one of those I had to specially download when playing with link time optimization.    