### PR TITLE
Clean up use of `snprintf`/`vsnprintf` to use C++11 standard functions.

### DIFF
--- a/source/base/configbase.h
+++ b/source/base/configbase.h
@@ -10,7 +10,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -678,6 +678,17 @@
     // The following two lines work around doxygen being unable to document undefined macros.
     #define POV_SYS_IMAGE_EXTENSION (undefined)
     #undef POV_SYS_IMAGE_EXTENSION
+#endif
+
+/// @def POV_FILENAME_BUFFER_CHARS
+/// The number of characters to reserve for file name buffers.
+///
+/// This setting is used in allocating temporary buffers to construct file names, and should be set
+/// to the maximum number of ASCII characters in a file name the system can handle safely.
+/// The value is understood to exclude any terminating NUL character.
+///
+#ifndef POV_FILENAME_BUFFER_CHARS
+    #define POV_FILENAME_BUFFER_CHARS 199
 #endif
 
 /// @def POV_PATH_SEPARATOR

--- a/source/base/fileinputoutput.cpp
+++ b/source/base/fileinputoutput.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -38,6 +38,7 @@
 
 // C++ variants of standard C header files
 #include <cstdarg>
+#include <cstdio>
 #include <cstdlib>
 
 // Standard C++ header files
@@ -301,7 +302,7 @@ void OStream::printf(const char *format, ...)
     char buffer[1024];
 
     va_start(marker, format);
-    vsnprintf(buffer, 1023, format, marker);
+    std::vsnprintf(buffer, sizeof(buffer), format, marker);
     va_end(marker);
 
     write(reinterpret_cast<const void *>(buffer), strlen(buffer));

--- a/source/base/messenger.cpp
+++ b/source/base/messenger.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -74,7 +74,7 @@ void GenericMessenger::Info(const char *format, ...)
     sprintf(localvsbuffer, "%s Info: ", stageName);
 
     va_start(marker, format);
-    vsnprintf(localvsbuffer + strlen(localvsbuffer), 1023 - strlen(localvsbuffer), format, marker);
+    std::vsnprintf(localvsbuffer + strlen(localvsbuffer), sizeof(localvsbuffer) - strlen(localvsbuffer), format, marker);
     va_end(marker);
 
     CleanupString(localvsbuffer);
@@ -94,7 +94,7 @@ void GenericMessenger::InfoAt(const UCS2 *filename, POV_LONG line, POV_LONG colu
     sprintf(localvsbuffer, "%s Info: ", stageName);
 
     va_start(marker, format);
-    vsnprintf(localvsbuffer + strlen(localvsbuffer), 1023 - strlen(localvsbuffer), format, marker);
+    std::vsnprintf(localvsbuffer + strlen(localvsbuffer), sizeof(localvsbuffer) - strlen(localvsbuffer), format, marker);
     va_end(marker);
 
     CleanupString(localvsbuffer);
@@ -113,7 +113,7 @@ void GenericMessenger::Warning(WarningLevel level, const char *format,...)
     sprintf(localvsbuffer, "%s Warning: ", stageName);
 
     va_start(marker, format);
-    vsnprintf(localvsbuffer + strlen(localvsbuffer), 1023 - strlen(localvsbuffer), format, marker);
+    std::vsnprintf(localvsbuffer + strlen(localvsbuffer), sizeof(localvsbuffer) - strlen(localvsbuffer), format, marker);
     va_end(marker);
 
     CleanupString(localvsbuffer);
@@ -132,7 +132,7 @@ void GenericMessenger::WarningAt(WarningLevel level, const UCS2 *filename, POV_L
     sprintf(localvsbuffer, "%s Warning: ", stageName);
 
     va_start(marker, format);
-    vsnprintf(localvsbuffer + strlen(localvsbuffer), 1023 - strlen(localvsbuffer), format, marker);
+    std::vsnprintf(localvsbuffer + strlen(localvsbuffer), sizeof(localvsbuffer) - strlen(localvsbuffer), format, marker);
     va_end(marker);
 
     CleanupString(localvsbuffer);
@@ -151,7 +151,7 @@ void GenericMessenger::PossibleError(const char *format,...)
     sprintf(localvsbuffer, "Possible %s Error: ", stageName);
 
     va_start(marker, format);
-    vsnprintf(localvsbuffer + strlen(localvsbuffer), 1023 - strlen(localvsbuffer), format, marker);
+    std::vsnprintf(localvsbuffer + strlen(localvsbuffer), sizeof(localvsbuffer) - strlen(localvsbuffer), format, marker);
     va_end(marker);
 
     CleanupString(localvsbuffer);
@@ -170,7 +170,7 @@ void GenericMessenger::PossibleErrorAt(const UCS2 *filename, POV_LONG line, POV_
     sprintf(localvsbuffer, "Possible %s Error: ", stageName);
 
     va_start(marker, format);
-    vsnprintf(localvsbuffer + strlen(localvsbuffer), 1023 - strlen(localvsbuffer), format, marker);
+    std::vsnprintf(localvsbuffer + strlen(localvsbuffer), sizeof(localvsbuffer) - strlen(localvsbuffer), format, marker);
     va_end(marker);
 
     CleanupString(localvsbuffer);
@@ -184,7 +184,7 @@ std::string GenericMessenger::SendError(const char *format, va_list arglist, con
     char localvsbuffer[1024];
 
     sprintf(localvsbuffer, "%s Error: ", stageName);
-    vsnprintf(localvsbuffer + strlen(localvsbuffer), 1023 - strlen(localvsbuffer), format, arglist);
+    std::vsnprintf(localvsbuffer + strlen(localvsbuffer), sizeof(localvsbuffer) - strlen(localvsbuffer), format, arglist);
     CleanupString(localvsbuffer);
 
     SendMessage(kMessageClass_Error, kWarningNone, localvsbuffer, filename, line, column, offset);

--- a/source/base/stringutilities.cpp
+++ b/source/base/stringutilities.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -323,7 +323,7 @@ const char *pov_tsprintf(const char *format,...)
     static char pov_tsprintf_buffer[1024];
 
     va_start(marker, format);
-    vsnprintf(pov_tsprintf_buffer, 1023, format, marker);
+    std::vsnprintf(pov_tsprintf_buffer, sizeof(pov_tsprintf_buffer), format, marker);
     va_end(marker);
 
     return pov_tsprintf_buffer;

--- a/source/base/textstream.cpp
+++ b/source/base/textstream.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -38,6 +38,7 @@
 
 // C++ variants of standard C header files
 #include <cstdarg>
+#include <cstdio>
 #include <cstdlib>
 
 // Standard C++ header files
@@ -472,7 +473,7 @@ void OTextStream::printf(const char *format, ...)
     char buffer[1024];
 
     va_start(marker, format);
-    vsnprintf(buffer, 1023, format, marker);
+    std::vsnprintf(buffer, sizeof(buffer), format, marker);
     va_end(marker);
 
 #ifdef POV_NEW_LINE_STRING

--- a/source/base/textstreambuffer.cpp
+++ b/source/base/textstreambuffer.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -38,6 +38,7 @@
 
 // C++ variants of standard C header files
 #include <cstdarg>
+#include <cstdio>
 #include <cstring>
 
 // Standard C++ header files
@@ -81,7 +82,7 @@ void TextStreamBuffer::printf(const char *format, ...)
     va_list marker;
 
     va_start(marker, format);
-    vsnprintf(&buffer[boffset], bsize - boffset - 1, format, marker);
+    std::vsnprintf(&buffer[boffset], bsize - boffset, format, marker);
     va_end(marker);
 
     // direct output

--- a/source/frontend/processoptions.cpp
+++ b/source/frontend/processoptions.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -35,6 +35,8 @@
 
 // Unit header file must be the first file included within POV-Ray *.cpp files (pulls in config)
 #include "frontend/processoptions.h"
+
+#include <cstdio>
 
 #include "base/platformbase.h"
 
@@ -541,7 +543,7 @@ void ProcessOptions::ParseError(const char *format, ...)
     char error_buffer[1024];
 
     va_start(marker, format);
-    vsnprintf(error_buffer, 1023, format, marker);
+    std::vsnprintf(error_buffer, sizeof(error_buffer), format, marker);
     va_end(marker);
 
     fprintf(stderr, "%s\n", error_buffer);
@@ -553,7 +555,7 @@ void ProcessOptions::ParseErrorAt(ITextStream *file, const char *format, ...)
     char error_buffer[1024];
 
     va_start(marker, format);
-    vsnprintf(error_buffer, 1023, format, marker);
+    std::vsnprintf(error_buffer, sizeof(error_buffer), format, marker);
     va_end(marker);
 
     fprintf(stderr, "%s\nFile '%s' at line '%u'", error_buffer, UCS2toASCIIString(file->name()).c_str(), (unsigned int) file->line());
@@ -565,7 +567,7 @@ void ProcessOptions::WriteError(const char *format, ...)
     char error_buffer[1024];
 
     va_start(marker, format);
-    vsnprintf(error_buffer, 1023, format, marker);
+    std::vsnprintf(error_buffer, sizeof(error_buffer), format, marker);
     va_end(marker);
 
     fprintf(stderr, "%s\n", error_buffer);
@@ -942,7 +944,7 @@ int ProcessOptions::Parse_INI_Switch(ITextStream *file, int token, POVMSObjectPt
                 else if((value != NULL) && (*srcptr == 0))
                     srcptr = value;
 
-                // only if a paremeter is expected allow it, and vice versa
+                // only if a parameter is expected allow it, and vice versa
                 if ((table->flags & kCmdOptFlag_Optional) ||
                     ((*srcptr >  ' ') && (table->type != kPOVMSType_Null)) ||
                     ((*srcptr <= ' ') && (table->type == kPOVMSType_Null)))
@@ -1251,7 +1253,7 @@ int ProcessOptions::Parse_CL_Switch(const char *&commandline, int token, POVMSOb
                 else if((value != NULL) && (*srcptr == 0))
                     srcptr = value;
 
-                // only if a paremeter is expected allow it, and vice versa
+                // only if a parameter is expected allow it, and vice versa
                 if ((table->flags & kCmdOptFlag_Optional) ||
                     ((*srcptr >  ' ') && (table->type != kPOVMSType_Null)) ||
                     ((*srcptr <= ' ') && (table->type == kPOVMSType_Null)))

--- a/source/parser/parser.cpp
+++ b/source/parser/parser.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -39,6 +39,8 @@
 // C++ variants of C standard header files
 #include <cctype>
 #include <cmath>
+#include <cstdarg>
+#include <cstdio>
 #include <cstdlib>
 
 // C++ standard header files
@@ -179,7 +181,7 @@ void Parser::Run()
 {
     int         error_line = -1;
     int         error_col = -1;
-    UCS2String  error_filename(MAX_PATH, 0); // Pre-claim some memory, so we can handle an out-of-memory error.
+    UCS2String  error_filename(POV_FILENAME_BUFFER_CHARS, 0); // Pre-claim some memory, so we can handle an out-of-memory error.
     POV_LONG    error_pos = -1;
 
     try
@@ -253,7 +255,7 @@ void Parser::Run()
             if (Token.FileHandle != NULL)
             {
                 // take a (local) copy of error location prior to freeing token data
-                // NB error_filename has been pre-allocated for strings up to _MAX_PATH
+                // NB error_filename has been pre-allocated for strings up to POV_FILENAME_BUFFER_CHARS
                 error_filename = Token.FileHandle->name();
                 error_line = Token.Token_File_Pos.lineno;
                 error_col = Token.Token_Col_No;
@@ -10772,7 +10774,7 @@ void Parser::Warning(const char *format,...)
     char localvsbuffer[1024];
 
     va_start(marker, format);
-    vsnprintf(localvsbuffer, 1023, format, marker);
+    std::vsnprintf(localvsbuffer, sizeof(localvsbuffer), format, marker);
     va_end(marker);
 
     Warning(kWarningGeneral, localvsbuffer);
@@ -10786,7 +10788,7 @@ void Parser::Warning(WarningLevel level, const char *format,...)
     char localvsbuffer[1024];
 
     va_start(marker, format);
-    vsnprintf(localvsbuffer, 1023, format, marker);
+    std::vsnprintf(localvsbuffer, sizeof(localvsbuffer), format, marker);
     va_end(marker);
 
     if(Token.FileHandle != NULL)
@@ -10803,7 +10805,7 @@ void Parser::VersionWarning(unsigned int sinceVersion, const char *format,...)
         char localvsbuffer[1024];
 
         va_start(marker, format);
-        vsnprintf(localvsbuffer, 1023, format, marker);
+        std::vsnprintf(localvsbuffer, sizeof(localvsbuffer), format, marker);
         va_end(marker);
 
         Warning(kWarningLanguage, localvsbuffer);
@@ -10816,7 +10818,7 @@ void Parser::PossibleError(const char *format,...)
     char localvsbuffer[1024];
 
     va_start(marker, format);
-    vsnprintf(localvsbuffer, 1023, format, marker);
+    std::vsnprintf(localvsbuffer, sizeof(localvsbuffer), format, marker);
     va_end(marker);
 
     if(Token.FileHandle != NULL)
@@ -10835,7 +10837,7 @@ void Parser::Error(const char *format,...)
     char localvsbuffer[1024];
 
     va_start(marker, format);
-    vsnprintf(localvsbuffer, 1023, format, marker);
+    std::vsnprintf(localvsbuffer, sizeof(localvsbuffer), format, marker);
     va_end(marker);
 
     if(Token.FileHandle != NULL)
@@ -10850,7 +10852,7 @@ void Parser::ErrorInfo(const SourceInfo& loc, const char *format,...)
     char localvsbuffer[1024];
 
     va_start(marker, format);
-    vsnprintf(localvsbuffer, 1023, format, marker);
+    std::vsnprintf(localvsbuffer, sizeof(localvsbuffer), format, marker);
     va_end(marker);
 
     messageFactory.PossibleErrorAt(loc.filename, loc.filepos.lineno, loc.col, loc.filepos.offset, "%s", localvsbuffer);
@@ -10862,7 +10864,7 @@ int Parser::Debug_Info(const char *format,...)
     char localvsbuffer[1024];
 
     va_start(marker, format);
-    vsnprintf(localvsbuffer, 1023, format, marker);
+    std::vsnprintf(localvsbuffer, sizeof(localvsbuffer), format, marker);
     va_end(marker);
 
     Debug_Message_Buffer.printf("%s", localvsbuffer);

--- a/source/parser/parser_strings.cpp
+++ b/source/parser/parser_strings.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -38,6 +38,7 @@
 
 // C++ variants of C standard header files
 #include <cctype>
+#include <cstdio>
 #include <cstdlib>
 
 // Boost header files
@@ -226,13 +227,13 @@ UCS2 *Parser::Parse_Str(bool pathname)
     // TODO: consider changing to %g rather than %f for large numbers (e.g.
     // anything over 1e+64 for example). for now, we will only use %g if the
     // snprintf filled the buffer.
-    // NB test for < 0 is because stupid windows _snprintf can return negative values.
-    if (((l = snprintf(temp4, sizeof(temp4) - 1, temp3, val)) >= sizeof(temp4) - 1) || (l < 0))
+    // NB `snprintf` may report errors via a negative return value.
+    if (((l = std::snprintf(temp4, sizeof(temp4), temp3, val)) >= sizeof(temp4)) || (l < 0))
     {
         *p = 'g';
 
         // it should not be possible to overflow with %g. but just in case ...
-        if (((l = snprintf(temp4, sizeof(temp4) - 1, temp3, val)) >= sizeof(temp4) - 1) || (l < 0))
+        if (((l = std::snprintf(temp4, sizeof(temp4), temp3, val)) >= sizeof(temp4)) || (l < 0))
             strcpy(temp4, "<invalid>");
     }
 

--- a/unix/configure.ac
+++ b/unix/configure.ac
@@ -613,23 +613,6 @@ AC_LANG_POP([C])
 #AC_FUNC_STRFTIME  # FIXME
 #AC_FUNC_VPRINTF   # FIXME
 
-# vsnprintf <stdarg.h> (C99)
-AC_CHECK_FUNC([vsnprintf],
-  [],
-  [AC_MSG_ERROR([
-*** This system does not provide the C99 vsnprintf() function which
-*** is required to compile $PACKAGE_NAME.  You should consider updating
-*** your C library as it is too old.  Alternatively you might install
-*** a specific library implementing the (v)snprintf family of functions.
-*** Searching the web should give you appropriate pointers.
-***
-*** In case you want to try compiling $PACKAGE_NAME while your system lacks
-*** this function (meaning that compilation *will* fail unless you provide
-*** a replacement function), try the --disable-vsnprintf-check option.
-])
-  ]
-)
-
 # getcwd or its equivalent with getenv <unistd.h>
 AC_LANG_PUSH([C])
 AC_CHECK_FUNCS([getcwd],

--- a/unix/povconfig/syspovconfig.h
+++ b/unix/povconfig/syspovconfig.h
@@ -11,7 +11,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -102,7 +102,7 @@ using boost::intrusive_ptr;
 
 #endif // STD_POV_TYPES_DECLARED
 
-// After Stroustrop in _The C++ Programming Language, 3rd Ed_ p. 88
+// After Stroustrup in _The C++ Programming Language, 3rd Ed_ p. 88
 #ifndef NULL
 const int NULL=0;
 #endif
@@ -110,13 +110,17 @@ const int NULL=0;
 #define POV_DELETE_FILE(name)  unlink(name)
 
 #if defined (PATH_MAX)
-# define FILE_NAME_LENGTH   PATH_MAX
+    // Use the system's actual limit if known.
+    // NB: PATH_MAX is understood including a terminating NUL character.
+    #define POV_FILENAME_BUFFER_CHARS   (PATH_MAX-1)
 #elif defined (_POSIX_PATH_MAX)
-# define FILE_NAME_LENGTH   _POSIX_PATH_MAX
+    // Otherwise, use the most restrictive limit allowed by POSIX if defined.
+    // NB: _POSIX_PATH_MAX is understood including a terminating NUL character.
+    #define POV_FILENAME_BUFFER_CHARS   (_POSIX_PATH_MAX-1)
 #else
-# define FILE_NAME_LENGTH   200
+    // As a fallback, use an even more conservative limit.
+    #define POV_FILENAME_BUFFER_CHARS   199
 #endif
-#define MAX_PATH FILE_NAME_LENGTH  // FIXME: remove later
 
 #define DEFAULT_OUTPUT_FORMAT       kPOVList_FileType_PNG
 #define DEFAULT_DISPLAY_GAMMA_TYPE  kPOVList_GammaType_SRGB

--- a/vfe/unix/vfeplatform.cpp
+++ b/vfe/unix/vfeplatform.cpp
@@ -10,7 +10,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -39,6 +39,7 @@
 #include "syspovconfig.h"
 
 // C++ variants of C standard headers
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #ifdef HAVE_TIME_H
@@ -145,8 +146,9 @@ namespace vfePlatform
     // name to one that it can use.
     UCS2String vfeUnixSession::CreateTemporaryFile(void) const
     {
-        char str [FILE_NAME_LENGTH] = "";
-        snprintf(str, FILE_NAME_LENGTH, "%spov%d", m_OptionsProc->GetTemporaryPath().c_str(), getpid ());
+        // TODO FIXME - This allows only one temporary file per process!
+        char str [POV_FILENAME_BUFFER_CHARS+1] = "";
+        std::snprintf(str, sizeof(str), "%spov%d", m_OptionsProc->GetTemporaryPath().c_str(), getpid ());
         POV_DELETE_FILE (str);
 
         return ASCIItoUCS2String (str);

--- a/vfe/vfe.cpp
+++ b/vfe/vfe.cpp
@@ -10,7 +10,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -41,6 +41,9 @@
 #endif
 
 #include "vfe.h"
+
+#include <cstdarg>
+#include <cstdio>
 
 #include "frontend/animationprocessing.h"
 #include "frontend/imageprocessing.h"
@@ -547,7 +550,7 @@ void vfeProcessRenderOptions::ParseError(const char *format, ...)
   va_list marker;
 
   va_start(marker, format);
-  vsnprintf(str, sizeof(str)-2, format, marker);
+  std::vsnprintf(str, sizeof(str), format, marker);
   va_end(marker);
 
   m_Session->AppendStatusMessage (str);
@@ -561,7 +564,7 @@ void vfeProcessRenderOptions::ParseErrorAt(ITextStream *file, const char *format
   va_list marker;
 
   va_start(marker, format);
-  vsnprintf(str, sizeof(str)-2, format, marker);
+  std::vsnprintf(str, sizeof(str), format, marker);
   va_end(marker);
 
   m_Session->AppendStatusMessage (str);
@@ -575,7 +578,7 @@ void vfeProcessRenderOptions::WriteError(const char *format, ...)
   va_list marker;
 
   va_start(marker, format);
-  vsnprintf(str, sizeof(str)-2, format, marker);
+  std::vsnprintf(str, sizeof(str), format, marker);
   va_end(marker);
 
   m_Session->AppendStatusMessage (str);

--- a/vfe/vfecontrol.cpp
+++ b/vfe/vfecontrol.cpp
@@ -10,7 +10,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -211,7 +211,7 @@ void vfeSession::RenderStopped (void)
 int vfeSession::SetOptions (vfeRenderOptions& opts)
 {
   int                     err;
-  UCS2                    str [MAX_PATH];
+  UCS2                    str[POV_FILENAME_BUFFER_CHARS+1]; // TODO FIXME - use a C++ style string instead.
   POVMSObject             obj;
   vfeProcessRenderOptions options(this);
 

--- a/windows/povconfig/syspovconfig.h
+++ b/windows/povconfig/syspovconfig.h
@@ -13,7 +13,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -227,10 +227,7 @@ namespace pov_base
 #define POV_NEW_LINE_STRING                 "\r\n"
 #define POV_SYS_IMAGE_EXTENSION             ".bmp"
 #define POV_SYS_IMAGE_TYPE                  BMP
-#define vsnprintf                           _vsnprintf
-#define snprintf                            _snprintf
-#define FILE_NAME_LENGTH                    _MAX_PATH
-#define POV_NAME_MAX                        _MAX_FNAME
+#define POV_FILENAME_BUFFER_CHARS           (_MAX_PATH-1)   // (NB: _MAX_PATH includes terminating NUL character)
 #define IFF_SWITCH_CAST                     (long)
 #define USE_OFFICIAL_BOOST                  1
 
@@ -279,7 +276,7 @@ namespace pov
 }
 #endif // end of not _CONSOLE
 
-// see RLP comment in 3.6 windows config.h
+// see RLP comment in v3.6 windows config.h
 #undef HUGE_VAL
 
 // use a larger buffer for more efficient parsing
@@ -290,6 +287,7 @@ namespace pov
   #define OBJECT_DEBUG_HELPER
 #endif
 
+// TODO REVIEW - Is this actually required for any Windows platform?
 #ifndef MAX_PATH
   #define MAX_PATH _MAX_PATH
 #endif

--- a/windows/pvtext.cpp
+++ b/windows/pvtext.cpp
@@ -10,7 +10,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -1038,7 +1038,7 @@ void draw_ordinary_listbox (DRAWITEMSTRUCT *d, bool fitpath)
   int         dividerStep ;
   int         width ;
   int         length ;
-  char        str [MAX_PATH] ;
+  char        str [MAX_PATH] ; // TODO FIXME - this isn't safe
   RECT        rect ;
   HPEN        hpen1 ;
   HPEN        hpen2 ;


### PR DESCRIPTION
Also replace `FILE_NAME_LENGTH` macro along the way in hope to clarify the code, and eliminate `MAX_PATH` from all but the Windows-specific code.