### PR TITLE
Fixing density_map by defined id parsing.

### DIFF
--- a/source/parser/parser_expressions.cpp
+++ b/source/parser/parser_expressions.cpp
@@ -2825,7 +2825,7 @@ shared_ptr<MAP_T> Parser::Parse_Blend_Map (BlendMapTypeId Blend_Type,int Pat_Typ
     Parse_Begin ();
 
     EXPECT
-        CASE2 (COLOUR_MAP_ID_TOKEN, PIGMENT_MAP_ID_TOKEN)
+        CASE3 (COLOUR_MAP_ID_TOKEN, PIGMENT_MAP_ID_TOKEN, DENSITY_MAP_ID_TOKEN)
         CASE3 (NORMAL_MAP_ID_TOKEN, TEXTURE_MAP_ID_TOKEN, SLOPE_MAP_ID_TOKEN)
             New = Copy_Blend_Map (*(reinterpret_cast<shared_ptr<MAP_T> *> (Token.Data)));
             if (Blend_Type != New->Type)


### PR DESCRIPTION
Including some testing sdl which should all run cleanly, but which doesn't without this fix in the last media block case. 

```
#version 3.8;
global_settings { assumed_gamma 1 }

//---- color_maps work as expected...
// media {
//   emission 0.75
//   scattering {1, 0.5}
//   density {
//     spherical
//     color_map {
//       [0.0 rgb <0,0,0.5>]
//       [0.5 rgb <0.8, 0.8, 0.4>]
//       [1.0 rgb <1,1,1>]
//     }
//   }
// }
//
// #declare ColorMap00 =
//     color_map {
//       [0.0 rgb <0,0,0.5>]
//       [0.5 rgb <0.8, 0.8, 0.4>]
//       [1.0 rgb <1,1,1>]
//     }
//
// media {
//   emission 0.75
//   scattering {1, 0.5}
//   density {
//     spherical
//     color_map { ColorMap00 }
//   }
// }


//---- density_maps do NOT work as expected without fix.
//
// media {
//   emission 0.75
//   scattering {1, 0.5}
//   density {
//     spherical
//     density_map {
//       [0.0 rgb <0,0,0.5>]
//       [0.5 rgb <0.8, 0.8, 0.4>]
//       [1.0 rgb <1,1,1>]
//     }
//   }
// }

   #declare DensityMap00 =
       density_map {
         [0.0 rgb <0,0,0.5>]
         [0.5 rgb <0.8, 0.8, 0.4>]
         [1.0 rgb <1,1,1>]
       }

   media {
     emission 0.75
     scattering {1, 0.5}
     density {
       spherical
       density_map { DensityMap00 }
     }
   }
```


