### PR TITLE
fix for FS324, regression on triangle

### DIFF
--- a/source/core/configcore.h
+++ b/source/core/configcore.h
@@ -198,7 +198,7 @@
 /// @note
 ///     Some algorithms use @ref SMALL_TOLERANCE instead.
 ///
-#define MIN_ISECT_DEPTH 1.0e-4
+#define MIN_ISECT_DEPTH 0.0
 
 /// @}
 ///

--- a/source/core/render/trace.cpp
+++ b/source/core/render/trace.cpp
@@ -366,7 +366,7 @@ bool Trace::FindIntersection(ObjectPtr object, Intersection& isect, const Ray& r
             {
                 tmpDepth = depthstack->top().Depth;
                 // TODO FIXME - This was SMALL_TOLERANCE, but that's too rough for some scenes [cjc] need to check what it was in the old code [trf]
-                if(tmpDepth < closest && (ray.IsSubsurfaceRay() || tmpDepth >= MIN_ISECT_DEPTH))
+                if(tmpDepth < closest && (ray.IsSubsurfaceRay() || tmpDepth > MIN_ISECT_DEPTH))
                 {
                     isect = depthstack->top();
                     closest = tmpDepth;
@@ -419,7 +419,7 @@ bool Trace::FindIntersection(ObjectPtr object, Intersection& isect, const Ray& r
             {
                 tmpDepth = depthstack->top().Depth;
                 // TODO FIXME - This was SMALL_TOLERANCE, but that's too rough for some scenes [cjc] need to check what it was in the old code [trf]
-                if(tmpDepth < closest && (ray.IsSubsurfaceRay() || tmpDepth >= MIN_ISECT_DEPTH) && postcondition(ray, object, tmpDepth))
+                if(tmpDepth < closest && (ray.IsSubsurfaceRay() || tmpDepth > MIN_ISECT_DEPTH) && postcondition(ray, object, tmpDepth))
                 {
                     isect = depthstack->top();
                     closest = tmpDepth;

--- a/source/core/scene/object.cpp
+++ b/source/core/scene/object.cpp
@@ -137,7 +137,7 @@ bool Find_Intersection(Intersection *isect, ObjectPtr object, const Ray& ray, Tr
             {
                 tmpDepth = depthstack->top().Depth;
                 // TODO FIXME - This was SMALL_TOLERANCE, but that's too rough for some scenes [cjc] need to check what it was in the old code [trf]
-                if(tmpDepth < closest && (ray.IsSubsurfaceRay() || tmpDepth >= MIN_ISECT_DEPTH))
+                if(tmpDepth < closest && (ray.IsSubsurfaceRay() || tmpDepth > MIN_ISECT_DEPTH))
                 {
                     *isect = depthstack->top();
                     closest = tmpDepth;
@@ -191,7 +191,7 @@ bool Find_Intersection(Intersection *isect, ObjectPtr object, const Ray& ray, co
             {
                 tmpDepth = depthstack->top().Depth;
                 // TODO FIXME - This was SMALL_TOLERANCE, but that's too rough for some scenes [cjc] need to check what it was in the old code [trf]
-                if(tmpDepth < closest && (ray.IsSubsurfaceRay() || tmpDepth >= MIN_ISECT_DEPTH) && postcondition(ray, object, tmpDepth))
+                if(tmpDepth < closest && (ray.IsSubsurfaceRay() || tmpDepth > MIN_ISECT_DEPTH) && postcondition(ray, object, tmpDepth))
                 {
                     *isect = depthstack->top();
                     closest = tmpDepth;
@@ -237,7 +237,7 @@ bool Find_Intersection(Intersection *isect, ObjectPtr object, const Ray& ray, BB
             {
                 tmpDepth = depthstack->top().Depth;
                 // TODO FIXME - This was SMALL_TOLERANCE, but that's too rough for some scenes [cjc] need to check what it was in the old code [trf]
-                if(tmpDepth < closest && (ray.IsSubsurfaceRay() || tmpDepth >= MIN_ISECT_DEPTH))
+                if(tmpDepth < closest && (ray.IsSubsurfaceRay() || tmpDepth > MIN_ISECT_DEPTH))
                 {
                     *isect = depthstack->top();
                     closest = tmpDepth;
@@ -283,7 +283,7 @@ bool Find_Intersection(Intersection *isect, ObjectPtr object, const Ray& ray, BB
             {
                 tmpDepth = depthstack->top().Depth;
                 // TODO FIXME - This was SMALL_TOLERANCE, but that's too rough for some scenes [cjc] need to check what it was in the old code [trf]
-                if(tmpDepth < closest && (ray.IsSubsurfaceRay() || tmpDepth >= MIN_ISECT_DEPTH) && postcondition(ray, object, tmpDepth))
+                if(tmpDepth < closest && (ray.IsSubsurfaceRay() || tmpDepth > MIN_ISECT_DEPTH) && postcondition(ray, object, tmpDepth))
                 {
                     *isect = depthstack->top();
                     closest = tmpDepth;
@@ -904,24 +904,25 @@ ObjectPtr CompoundObject::Invert()
 bool ObjectBase::Intersect_BBox(BBoxDirection variant, const BBoxVector3d& origin, const BBoxVector3d& invdir, BBoxScalar maxd) const
 {
     // TODO FIXME - This was SMALL_TOLERANCE, but that's too rough for some scenes [cjc] need to check what it was in the old code [trf]
+    // reverting to SMALL_TOLERANCE and using a far smaller MIN_ISECT_DEPTH with a strictly greater check, for FS324 [jg]
     switch(variant)
     {
         case BBOX_DIR_X0Y0Z0: // 000
-            return Intersect_BBox_Dir<0, 0, 0>(BBox, origin, invdir, MIN_ISECT_DEPTH, maxd);
+            return Intersect_BBox_Dir<0, 0, 0>(BBox, origin, invdir, SMALL_TOLERANCE, maxd);
         case BBOX_DIR_X0Y0Z1: // 001
-            return Intersect_BBox_Dir<0, 0, 1>(BBox, origin, invdir, MIN_ISECT_DEPTH, maxd);
+            return Intersect_BBox_Dir<0, 0, 1>(BBox, origin, invdir, SMALL_TOLERANCE, maxd);
         case BBOX_DIR_X0Y1Z0: // 010
-            return Intersect_BBox_Dir<0, 1, 0>(BBox, origin, invdir, MIN_ISECT_DEPTH, maxd);
+            return Intersect_BBox_Dir<0, 1, 0>(BBox, origin, invdir, SMALL_TOLERANCE, maxd);
         case BBOX_DIR_X0Y1Z1: // 011
-            return Intersect_BBox_Dir<0, 1, 1>(BBox, origin, invdir, MIN_ISECT_DEPTH, maxd);
+            return Intersect_BBox_Dir<0, 1, 1>(BBox, origin, invdir, SMALL_TOLERANCE, maxd);
         case BBOX_DIR_X1Y0Z0: // 100
-            return Intersect_BBox_Dir<1, 0, 0>(BBox, origin, invdir, MIN_ISECT_DEPTH, maxd);
+            return Intersect_BBox_Dir<1, 0, 0>(BBox, origin, invdir, SMALL_TOLERANCE, maxd);
         case BBOX_DIR_X1Y0Z1: // 101
-            return Intersect_BBox_Dir<1, 0, 1>(BBox, origin, invdir, MIN_ISECT_DEPTH, maxd);
+            return Intersect_BBox_Dir<1, 0, 1>(BBox, origin, invdir, SMALL_TOLERANCE, maxd);
         case BBOX_DIR_X1Y1Z0: // 110
-            return Intersect_BBox_Dir<1, 1, 0>(BBox, origin, invdir, MIN_ISECT_DEPTH, maxd);
+            return Intersect_BBox_Dir<1, 1, 0>(BBox, origin, invdir, SMALL_TOLERANCE, maxd);
         case BBOX_DIR_X1Y1Z1: // 111
-            return Intersect_BBox_Dir<1, 1, 1>(BBox, origin, invdir, MIN_ISECT_DEPTH, maxd);
+            return Intersect_BBox_Dir<1, 1, 1>(BBox, origin, invdir, SMALL_TOLERANCE, maxd);
     }
 
     return false; // unreachable


### PR DESCRIPTION
in mesh, mesh2 or alone, the 3.6 version was fine and got broken

As reported in #121 (scenes are from that issue)

Before (i.e. in 3.7):
![a37](https://user-images.githubusercontent.com/6189221/40587384-b179e0c0-61ce-11e8-871b-6443806ec205.png)
![b37](https://user-images.githubusercontent.com/6189221/40587385-b4210650-61ce-11e8-9f04-6fc788b0a0c2.png)

After:
![a](https://user-images.githubusercontent.com/6189221/40587393-c4799364-61ce-11e8-8be1-bbe70315b768.png)
![b](https://user-images.githubusercontent.com/6189221/40587396-c76d520e-61ce-11e8-8bd0-a56a9e47e5c3.png)


