### PR TITLE
Leaving mesh inside_vector untouched on transforms.

### DIFF
--- a/source/core/shape/mesh.cpp
+++ b/source/core/shape/mesh.cpp
@@ -10,7 +10,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -265,9 +265,7 @@ bool Mesh::Inside(const Vector3d& IPoint, TraceThreadData *Thread) const
     /* Transform the ray into mesh space. */
     if (Trans != NULL)
     {
-        MInvTransRay(ray, ray, Trans);
-
-        ray.Direction.normalize();
+        MInvTransPoint(ray.Origin, ray.Origin, Trans);
     }
 
     found = 0;


### PR DESCRIPTION
Formally, both the ray origin and the direction derived from the
inside_vector for the inside mesh test would see an inverse transform
into the mesh's coordinate space.  This would sometimes result in a
change in the inside_vector/ray direction with respect to the mesh.
Such direction changes are problematic given test ray directions roughly
perpendicular to a triangle's normal are noisy with respect to
ray-triangle intersections.

Running the attached test scene we correctly get the attached image where a planes texture is controlled by an object pattern based upon the mesh. The star mesh has a flat back very set just inside the plane surface. If the scene is run against the current master, the inside of the star mesh is missed. 

![meshinisidevect](https://user-images.githubusercontent.com/15925553/41203925-d029b4fe-6cab-11e8-8e4e-3964003cbf0c.png)
[MeshInisideVect.pov.txt](https://github.com/POV-Ray/povray/files/2088042/MeshInisideVect.pov.txt)
