### PR TITLE
Cache Images for faster parsing subsequent images (or frames in animation) #396

### DIFF
--- a/source/core/support/imageutil.cpp
+++ b/source/core/support/imageutil.cpp
@@ -1387,10 +1387,14 @@ ImageData *Copy_Image(ImageData *Old)
 
 void Destroy_Image(ImageData *image)
 {
-    if ((image == nullptr) || (--(image->References) > 0))
-        return;
+    return;
 
-    delete image;
+    // Images are now cached
+
+    // if ((image == nullptr) || (--(image->References) > 0))
+    //     return;
+    // 
+    // delete image;
 }
 
 ImageData::~ImageData()

--- a/source/core/support/imageutil.cpp
+++ b/source/core/support/imageutil.cpp
@@ -1397,6 +1397,11 @@ void Destroy_Image(ImageData *image)
     // delete image;
 }
 
+void Remove_Cached_Image(Image* image) {
+    delete image;
+}
+
+
 ImageData::~ImageData()
 {
 #ifdef POV_VIDCAP_IMPL

--- a/source/core/support/imageutil.cpp
+++ b/source/core/support/imageutil.cpp
@@ -1387,14 +1387,11 @@ ImageData *Copy_Image(ImageData *Old)
 
 void Destroy_Image(ImageData *image)
 {
-    return;
-
-    // Images are now cached
-
-    // if ((image == nullptr) || (--(image->References) > 0))
-    //     return;
-    // 
-    // delete image;
+    if ((image == nullptr) || (--(image->References) > 0))
+         return;
+    
+    image->data = nullptr; // Prevent the image from being deleted. Images are now cached.
+    delete image;
 }
 
 void Remove_Cached_Image(Image* image) {

--- a/source/core/support/imageutil.h
+++ b/source/core/support/imageutil.h
@@ -143,6 +143,7 @@ int map_pos(const Vector3d& EPoint, const ImageData* pImage, DBL *xcoor, DBL *yc
 ImageData *Copy_Image(ImageData *old);
 ImageData *Create_Image(void);
 void Destroy_Image(ImageData *image);
+void Remove_Cached_Image(Image* image);
 
 /// @}
 ///

--- a/source/parser/ImageCache.cpp
+++ b/source/parser/ImageCache.cpp
@@ -58,6 +58,7 @@
 #include "base/textstreambuffer.h"
 #include "base/image/image_fwd.h"
 #include "base/stringutilities.h"
+#include "core/support/imageutil.h"
 
 // this must be the last file included
 #include "base/povdebug.h"
@@ -67,7 +68,7 @@ namespace pov_image_cache
 {
 	using namespace pov_base;
 	using namespace std;
-	//static inline char* StrToChar(const std::string str);
+	using namespace pov;
 
 	struct ImageCacheEntry final
 	{
@@ -103,7 +104,8 @@ namespace pov_image_cache
 				return idx->second.image; //Cache[lookupFilename].image;
 			
 			// Remove old image from cache and release memory so the newer version can be loaded
-			delete idx->second.image;
+			//delete idx->second.image;
+			pov::Remove_Cached_Image(idx->second.image);
 			Cache.erase(idx);
 		}
 
@@ -127,7 +129,8 @@ namespace pov_image_cache
 		// Iterate over the map using Iterator till end.
 		while (it != Cache.end())
 		{
-			delete it->second.image;
+			//delete it->second.image;
+			pov::Remove_Cached_Image(it->second.image);
 			Cache.erase(it);
 		}
 	}

--- a/source/parser/ImageCache.cpp
+++ b/source/parser/ImageCache.cpp
@@ -37,8 +37,6 @@
 
 // C++ variants of C standard header files
 #include <map>
-#include <uchar.h>
-#include <cstring>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -59,6 +57,7 @@
 #include "base/textstream_fwd.h"
 #include "base/textstreambuffer.h"
 #include "base/image/image_fwd.h"
+#include "base/stringutilities.h"
 
 // this must be the last file included
 #include "base/povdebug.h"
@@ -68,9 +67,7 @@ namespace pov_image_cache
 {
 	using namespace pov_base;
 	using namespace std;
-	static inline std::string U16toString(const std::u16string& wstr);
-	static inline char* StrToChar(const std::string str);
-	static inline char* U16toChar(const std::u16string& wstr);
+	//static inline char* StrToChar(const std::string str);
 
 	struct ImageCacheEntry final
 	{
@@ -83,22 +80,20 @@ namespace pov_image_cache
 	// Gets the last modified time from the filesystem
 	__time64_t GetLastModifiedTime(const std::string filename)
 	{
-		char* cstrFilename = StrToChar(filename);
+		const char* cstrFilename = filename.c_str();
 
 		struct stat result;
 		if (stat(cstrFilename, &result) == 0)
 		{
-			delete cstrFilename;
 			return result.st_mtime;
 		}
-		delete cstrFilename;
 		return 0;
 	}
 
 	// Try to get the image from the cache
 	Image* GetCachedImage(const UCS2* filename)
 	{
-		std::string lookupFilename = U16toString(filename);
+		std::string lookupFilename = pov_base::UCS2toSysString(filename);
 		
 		std::map<std::string, ImageCacheEntry>::iterator idx = Cache.find(lookupFilename);
 		if (idx != Cache.end()) 
@@ -118,7 +113,7 @@ namespace pov_image_cache
 	// Store a new image into cache
 	void StoreImageInCache(const UCS2* filename, Image* image)
 	{
-		std::string lookupFilename = U16toString(filename);
+		std::string lookupFilename = pov_base::UCS2toSysString(filename);
 		__time64_t lastModified = GetLastModifiedTime(lookupFilename);
 		Cache[lookupFilename] = ImageCacheEntry{ image = image, lastModified = lastModified };
 	}
@@ -136,31 +131,4 @@ namespace pov_image_cache
 			Cache.erase(it);
 		}
 	}
-
-	static inline std::string U16toString(const std::u16string& wstr) 
-	{
-		std::string str = "";
-		char cstr[3] = "\0";
-		mbstate_t mbs;
-		for (const auto& it : wstr) {
-			memset(&mbs, 0, sizeof(mbs));//set shift state to the initial state
-			memmove(cstr, "\0\0\0", 3);
-			c16rtomb(cstr, it, &mbs);
-			str.append(std::string(cstr));
-		}//for
-		return str;
-	}
-
-	static inline char* StrToChar(const std::string str) 
-	{
-		char* cstring = new char[str.length() + 1];
-		strcpy(cstring, str.c_str());
-		return cstring;
-	}
-
-	static inline char* U16toChar(const std::u16string& wstr) 
-	{
-		return StrToChar(U16toString(wstr));
-	}
-
 }

--- a/source/parser/ImageCache.cpp
+++ b/source/parser/ImageCache.cpp
@@ -1,0 +1,166 @@
+//******************************************************************************
+///
+/// @file parser/ImageCache.cpp
+///
+/// This module implements a cache for images used in a scene so they only heve
+/// to be loaded once during animation rendering or between manual renders
+///
+/// @copyright
+/// @parblock
+///
+/// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
+/// Copyright 1991-2019 Persistence of Vision Raytracer Pty. Ltd.
+///
+/// POV-Ray is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU Affero General Public License as
+/// published by the Free Software Foundation, either version 3 of the
+/// License, or (at your option) any later version.
+///
+/// POV-Ray is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU Affero General Public License for more details.
+///
+/// You should have received a copy of the GNU Affero General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+///
+/// ----------------------------------------------------------------------------
+///
+/// POV-Ray is based on the popular DKB raytracer version 2.12.
+/// DKBTrace was originally written by David K. Buck.
+/// DKBTrace Ver 2.0-2.12 were written by David K. Buck & Aaron A. Collins.
+///
+/// @endparblock
+///
+//******************************************************************************
+
+
+// C++ variants of C standard header files
+#include <map>
+#include <xlocbuf>
+#include <cuchar>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#ifndef WIN32
+#include <unistd.h> // Unix lib for getting last modified file date and time
+#endif
+#ifdef WIN32
+#define stat _stat // Windows lib for getting last modified file date and time
+#endif
+
+
+// POV-Ray header files (base module)
+#include "base/base_fwd.h"
+#include "base/messenger_fwd.h"
+#include "base/povassert.h"
+#include "base/stringtypes.h"
+#include "base/textstream_fwd.h"
+#include "base/textstreambuffer.h"
+#include "base/image/image_fwd.h"
+
+// this must be the last file included
+#include "base/povdebug.h"
+
+
+namespace pov_image_cache
+{
+	using namespace pov_base;
+	using namespace std;
+	static inline std::string U16toString(const std::u16string& wstr);
+	static inline char* StrToChar(const std::string str);
+	static inline char* U16toChar(const std::u16string& wstr);
+
+	struct ImageCacheEntry final
+	{
+		Image* image;
+		__time64_t lastModified;
+	};
+
+	static std::map<std::string, ImageCacheEntry> Cache; // <- The actual cache
+
+	// Gets the last modified time from the filesystem
+	__time64_t GetLastModifiedTime(const std::string filename)
+	{
+		char* cstrFilename = StrToChar(filename);
+
+		struct stat result;
+		if (stat(cstrFilename, &result) == 0)
+		{
+			delete cstrFilename;
+			return result.st_mtime;
+		}
+		delete cstrFilename;
+		return 0;
+	}
+
+	// Try to get the image from the cache
+	Image* GetCachedImage(const UCS2* filename)
+	{
+		std::string lookupFilename = U16toString(filename);
+		
+		std::map<std::string, ImageCacheEntry>::iterator idx = Cache.find(lookupFilename);
+		if (idx != Cache.end()) 
+		{
+			__time64_t lastModified = GetLastModifiedTime(lookupFilename);
+			if (lastModified == Cache[lookupFilename].lastModified) 
+				return idx->second.image; //Cache[lookupFilename].image;
+			
+			// Remove old image from cache and release memory so the newer version can be loaded
+			delete idx->second.image;
+			Cache.erase(idx);
+		}
+
+		return nullptr;
+	}
+
+	// Store a new image into cache
+	void StoreImageInCache(const UCS2* filename, Image* image)
+	{
+		std::string lookupFilename = U16toString(filename);
+		__time64_t lastModified = GetLastModifiedTime(lookupFilename);
+		Cache[lookupFilename] = ImageCacheEntry{ image = image, lastModified = lastModified };
+	}
+
+	// May be called frome some menu item, personally, I'd just close PovRay and start a new process (different scenes often share resources in my case)
+	// Do not allow calling it while parsing or rendering!
+	void ClearCache() 
+	{
+		std::map<std::string, ImageCacheEntry>::iterator it = Cache.begin();
+
+		// Iterate over the map using Iterator till end.
+		while (it != Cache.end())
+		{
+			delete it->second.image;
+			Cache.erase(it);
+		}
+	}
+
+	static inline std::string U16toString(const std::u16string& wstr) 
+	{
+		std::string str = "";
+		char cstr[3] = "\0";
+		mbstate_t mbs;
+		for (const auto& it : wstr) {
+			memset(&mbs, 0, sizeof(mbs));//set shift state to the initial state
+			memmove(cstr, "\0\0\0", 3);
+			c16rtomb(cstr, it, &mbs);
+			str.append(std::string(cstr));
+		}//for
+		return str;
+	}
+
+	static inline char* StrToChar(const std::string str) 
+	{
+		char* cstring = new char[str.length() + 1];
+		strcpy(cstring, str.c_str());
+		return cstring;
+	}
+
+	static inline char* U16toChar(const std::u16string& wstr) 
+	{
+		return StrToChar(U16toString(wstr));
+	}
+
+}

--- a/source/parser/ImageCache.cpp
+++ b/source/parser/ImageCache.cpp
@@ -73,20 +73,20 @@ namespace pov_image_cache
 	struct ImageCacheEntry final
 	{
 		Image* image;
-		__time64_t lastModified;
+		long lastModified;
 	};
 
 	static std::map<std::string, ImageCacheEntry> Cache; // <- The actual cache
 
 	// Gets the last modified time from the filesystem
-	__time64_t GetLastModifiedTime(const std::string filename)
+	long GetLastModifiedTime(const std::string filename)
 	{
 		const char* cstrFilename = filename.c_str();
 
 		struct stat result;
 		if (stat(cstrFilename, &result) == 0)
 		{
-			return result.st_mtime;
+			return (long)result.st_mtime;
 		}
 		return 0;
 	}
@@ -99,12 +99,11 @@ namespace pov_image_cache
 		std::map<std::string, ImageCacheEntry>::iterator idx = Cache.find(lookupFilename);
 		if (idx != Cache.end()) 
 		{
-			__time64_t lastModified = GetLastModifiedTime(lookupFilename);
+			long lastModified = GetLastModifiedTime(lookupFilename);
 			if (lastModified == Cache[lookupFilename].lastModified) 
 				return idx->second.image; //Cache[lookupFilename].image;
 			
 			// Remove old image from cache and release memory so the newer version can be loaded
-			//delete idx->second.image;
 			pov::Remove_Cached_Image(idx->second.image);
 			Cache.erase(idx);
 		}
@@ -116,7 +115,7 @@ namespace pov_image_cache
 	void StoreImageInCache(const UCS2* filename, Image* image)
 	{
 		std::string lookupFilename = pov_base::UCS2toSysString(filename);
-		__time64_t lastModified = GetLastModifiedTime(lookupFilename);
+		long lastModified = GetLastModifiedTime(lookupFilename);
 		Cache[lookupFilename] = ImageCacheEntry{ image = image, lastModified = lastModified };
 	}
 
@@ -129,7 +128,6 @@ namespace pov_image_cache
 		// Iterate over the map using Iterator till end.
 		while (it != Cache.end())
 		{
-			//delete it->second.image;
 			pov::Remove_Cached_Image(it->second.image);
 			Cache.erase(it);
 		}

--- a/source/parser/ImageCache.cpp
+++ b/source/parser/ImageCache.cpp
@@ -37,7 +37,6 @@
 
 // C++ variants of C standard header files
 #include <map>
-#include <xlocbuf>
 #include <cuchar>
 
 #include <sys/types.h>

--- a/source/parser/ImageCache.cpp
+++ b/source/parser/ImageCache.cpp
@@ -38,6 +38,7 @@
 // C++ variants of C standard header files
 #include <map>
 #include <uchar.h>
+#include <cstring>
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/source/parser/ImageCache.cpp
+++ b/source/parser/ImageCache.cpp
@@ -37,7 +37,7 @@
 
 // C++ variants of C standard header files
 #include <map>
-#include <cuchar>
+#include <uchar.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/source/parser/ImageCache.h
+++ b/source/parser/ImageCache.h
@@ -1,0 +1,79 @@
+//******************************************************************************
+///
+/// @file parser/ImageCache.h
+///
+/// Declarations related to the Image Cache.
+///
+/// @copyright
+/// @parblock
+///
+/// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
+/// Copyright 1991-2019 Persistence of Vision Raytracer Pty. Ltd.
+///
+/// POV-Ray is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU Affero General Public License as
+/// published by the Free Software Foundation, either version 3 of the
+/// License, or (at your option) any later version.
+///
+/// POV-Ray is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU Affero General Public License for more details.
+///
+/// You should have received a copy of the GNU Affero General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+///
+/// ----------------------------------------------------------------------------
+///
+/// POV-Ray is based on the popular DKB raytracer version 2.12.
+/// DKBTrace was originally written by David K. Buck.
+/// DKBTrace Ver 2.0-2.12 were written by David K. Buck & Aaron A. Collins.
+///
+/// @endparblock
+///
+//******************************************************************************
+
+#ifndef POVRAY_PARSER_IMAGE_CACHE_H
+#define POVRAY_PARSER_IMAGE_CACHE_H
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#ifndef WIN32
+#include <unistd.h> // Unix lib for getting last modified file date and time
+#endif
+#ifdef WIN32
+#define stat _stat // Windows lib for getting last modified file date and time
+#endif
+
+
+// POV-Ray header files (base module)
+#include "base/base_fwd.h"
+#include "base/messenger_fwd.h"
+#include "base/povassert.h"
+#include "base/stringtypes.h"
+#include "base/textstream_fwd.h"
+#include "base/textstreambuffer.h"
+#include "base/image/image_fwd.h"
+
+namespace pov
+{
+	class Blob_Element;
+	struct ContainedByShape;
+	struct GenericSpline;
+	class ImageData;
+	class Mesh;
+	struct PavementPattern;
+	struct TilingPattern;
+	struct TrueTypeFont;
+}
+
+namespace pov_image_cache
+{
+	using namespace pov_base;
+
+	Image* GetCachedImage(const UCS2* filename);
+	void StoreImageInCache(const UCS2* filename, Image* image);
+};
+
+#endif // POVRAY_PARSER_IMAGE_CACHE_H

--- a/windows/vs2015/povparser.vcxproj
+++ b/windows/vs2015/povparser.vcxproj
@@ -400,6 +400,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\source\parser\fncode.cpp" />
+    <ClCompile Include="..\..\source\parser\ImageCache.cpp" />
     <ClCompile Include="..\..\source\parser\parser.cpp" />
     <ClCompile Include="..\..\source\parser\parsertypes.cpp" />
     <ClCompile Include="..\..\source\parser\parser_expressions.cpp" />
@@ -424,6 +425,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\source\parser\fncode.h" />
+    <ClInclude Include="..\..\source\parser\ImageCache.h" />
     <ClInclude Include="..\..\source\parser\parser.h" />
     <ClInclude Include="..\..\source\parser\parsertypes.h" />
     <ClInclude Include="..\..\source\parser\parser_fwd.h" />

--- a/windows/vs2015/povparser.vcxproj.filters
+++ b/windows/vs2015/povparser.vcxproj.filters
@@ -46,6 +46,9 @@
     <ClInclude Include="..\..\source\parser\parser_fwd.h">
       <Filter>Parser Headers</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\source\parser\ImageCache.h">
+      <Filter>Parser Headers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\source\parser\parser.cpp">
@@ -91,6 +94,9 @@
       <Filter>Parser Source</Filter>
     </ClCompile>
     <ClCompile Include="..\..\source\parser\symboltable.cpp">
+      <Filter>Parser Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\source\parser\ImageCache.cpp">
       <Filter>Parser Source</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Loading large images during parsing can take ages. When rendering animations these images are reloaded before rendering each frame.

With this solution the images are only loaded once and cached for reuse when parsing the next frame. This can dramatically decrease parsing time.

Be free to point out any errors, this is my first serious C++ code written ever (normally I do C#).
The code has been tested and I don't see any significant memory leakage, in fact I am already using this in production (and it is saving lots of resources!).

I asked for this feature in issue #395 , instead of waiting for it I embarked on this rewarding quest.