### PR TITLE
Fix splines becoming linear when duplicated.

### DIFF
--- a/source/parser/parser_expressions.cpp
+++ b/source/parser/parser_expressions.cpp
@@ -31,16 +31,18 @@
 ///
 /// @endparblock
 ///
+//------------------------------------------------------------------------------
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //******************************************************************************
 
 // Unit header file must be the first file included within POV-Ray *.cpp files (pulls in config)
 #include "parser/parser.h"
 
-// C++ variants of C standard header files
+// C++ variants of standard C header files
 #include <cctype>
 #include <cstdlib>
 
-// C++ standard header files
+// Standard C++ header files
 #include <algorithm>
 
 // Boost header files
@@ -3726,7 +3728,7 @@ GenericSpline *Parser::Parse_Spline()
     if (!New)
     {
         if (Old)
-            New = new LinearSpline(*Old);
+            New = Old->Clone();
         else
             New = new LinearSpline();
     }


### PR DESCRIPTION
When used in `spline { SPLINE_IDENTIFIER ... }` without explicitly specifying spline type again, the new copy would get demoted to `linear_spline` (see newsgroup post `<XnsAD687938A665Aseed7@news.povray.org>`, 2021-07-15, povray.beta-test, "spline in, out array bug").