### PR TITLE
Partial fix for #428.

### DIFF
--- a/source/backend/control/scene.cpp
+++ b/source/backend/control/scene.cpp
@@ -143,28 +143,26 @@ void Scene::StartParser(POVMS_Object& parseOptions)
         parseOptions.Get(kPOVAttrib_Declare, ds);
         for(int i = 1; i <= ds.GetListSize(); i++)
         {
-            std::ostringstream sstr;
             POVMS_Attribute a;
             POVMS_Object d;
 
             ds.GetNth(i, d);
+            std::string ident = d.GetString(kPOVAttrib_Identifier);
             d.Get(kPOVAttrib_Value, a);
             switch (a.Type())
             {
                 case kPOVMSType_CString:
-                    sstr << "\"" + d.TryGetString(kPOVAttrib_Value, "") + "\"";
+                    sceneData->declaredStrings.insert(make_pair(ident, d.TryGetString(kPOVAttrib_Value, "")));
                     break;
 
                 case kPOVMSType_Float:
-                    sstr << d.TryGetFloat(kPOVAttrib_Value, 0.0);
+                    sceneData->declaredNumbers.insert(make_pair(ident, d.TryGetFloat(kPOVAttrib_Value, 0.0)));
                     break;
 
                 default:
                     // shouldn't happen unless we make a coding error
                     throw POV_EXCEPTION(kParamErr, "Invalid type passed in declare list");
             }
-
-            sceneData->declaredVariables.insert(make_pair(d.GetString(kPOVAttrib_Identifier), sstr.str()));
         }
     }
 

--- a/source/core/scene/scenedata.h
+++ b/source/core/scene/scenedata.h
@@ -81,7 +81,8 @@ class SceneData
 {
     public:
 
-        typedef std::map<string, string>         DeclaredVariablesMap;
+        typedef std::map<string, string>         DeclaredStringsMap;
+        typedef std::map<string, double>         DeclaredNumbersMap;
 
         /// Destructor.
         ~SceneData();
@@ -203,7 +204,8 @@ class SceneData
         int defaultFileType;
 
         FrameSettings frameSettings; // TODO - move ???
-        DeclaredVariablesMap declaredVariables; // TODO - move to parser
+        DeclaredStringsMap declaredStrings; // TODO - move to parser
+        DeclaredNumbersMap declaredNumbers; // TODO - move to parser
         Camera parsedCamera; // TODO - handle differently or move to parser
         bool clocklessAnimation; // TODO - this is support for an experimental feature and may be changed or removed
         vector<Camera> cameras; // TODO - this is support for an experimental feature and may be changed or removed

--- a/source/parser/parser.cpp
+++ b/source/parser/parser.cpp
@@ -212,25 +212,21 @@ void Parser::Run()
 
         Frame_Init ();
 
-        for(SceneData::DeclaredVariablesMap::const_iterator i(sceneData->declaredVariables.begin()); i != sceneData->declaredVariables.end(); i++)
+        for(SceneData::DeclaredStringsMap::const_iterator i(sceneData->declaredStrings.begin()); i != sceneData->declaredStrings.end(); i++)
         {
-            if(i->second.length() > 0)
-            {
-                SYM_ENTRY *Temp_Entry = nullptr;
+            SYM_ENTRY *Temp_Entry = nullptr;
 
-                if(i->second[0] == '\"')
-                {
-                    string tmp(i->second, 1, i->second.length() - 2);
-                    Temp_Entry = Add_Symbol(SYM_TABLE_GLOBAL, const_cast<char *>(i->first.c_str()), STRING_ID_TOKEN);
-                    Temp_Entry->Data = String_Literal_To_UCS2(const_cast<char *>(tmp.c_str()), false);
-                }
-                else
-                {
-                    Temp_Entry = Add_Symbol(SYM_TABLE_GLOBAL, const_cast<char *>(i->first.c_str()), FLOAT_ID_TOKEN);
-                    Temp_Entry->Data = Create_Float();
-                    *(reinterpret_cast<DBL *>(Temp_Entry->Data)) = std::atof(i->second.c_str());
-                }
-            }
+            Temp_Entry = Add_Symbol(SYM_TABLE_GLOBAL, const_cast<char *>(i->first.c_str()), STRING_ID_TOKEN);
+            Temp_Entry->Data = String_Literal_To_UCS2(const_cast<char *>(i->second.c_str()), false);
+        }
+
+        for (SceneData::DeclaredNumbersMap::const_iterator i(sceneData->declaredNumbers.begin()); i != sceneData->declaredNumbers.end(); i++)
+        {
+            SYM_ENTRY *Temp_Entry = nullptr;
+
+            Temp_Entry = Add_Symbol(SYM_TABLE_GLOBAL, const_cast<char *>(i->first.c_str()), FLOAT_ID_TOKEN);
+            Temp_Entry->Data = Create_Float();
+            *(reinterpret_cast<DBL *>(Temp_Entry->Data)) = i->second;
         }
 
         IncludeHeader(sceneData->headerFile);


### PR DESCRIPTION
Precision of `Declare` INI setting was erroneously truncated to 6 digits. Reverted back to 7 digits, matching v3.6 behavior.