### PR TITLE
Overhaul `datetime()` scene language function.

### DIFF
--- a/source/backend/povray.cpp
+++ b/source/backend/povray.cpp
@@ -50,6 +50,7 @@
 // POV-Ray header files (base module)
 #include "base/platformbase.h"
 #include "base/pov_err.h"
+#include "base/threadsafe.h"
 #include "base/timer.h"
 #include "base/types.h"
 
@@ -674,6 +675,7 @@ boost::thread *povray_init(const boost::function0<void>& threadExit, POVMSAddres
         POV_TerminateMainThread = false;
         POV_MainThreadTerminated = false;
 
+        pov_base::InitLocale();
         Initialize_Noise();
         pov::InitializePatternGenerators();
 

--- a/source/backend/scene/view.cpp
+++ b/source/backend/scene/view.cpp
@@ -39,13 +39,13 @@
 #include "backend/scene/view.h"
 
 // C++ variants of standard C header files
+//  (none at the moment)
 
 // Standard C++ header files
+#include <chrono>
 
 // Boost header files
 #include <boost/bind.hpp>
-#include <boost/date_time/gregorian/gregorian.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/math/common_factor.hpp>
 #if POV_MULTITHREADED
 #include <boost/thread.hpp>
@@ -733,9 +733,11 @@ void View::StartRender(POVMS_Object& renderOptions)
     seed = renderOptions.TryGetInt(kPOVAttrib_StochasticSeed, 0);
     if (seed == 0)
     {
-        boost::posix_time::ptime now = boost::posix_time::second_clock::universal_time();
-        boost::posix_time::ptime base = boost::posix_time::ptime(boost::gregorian::date(1970, 1, 1));
-        seed = (now - base).total_seconds();
+        // The following expression returns the number of _ticks_ elapsed since
+        // the system clock's _epoch_, where a _tick_ is the platform-dependent
+        // shortest time interval the system clock can measure, and _epoch_ is a
+        // platform-dependent point in time (usually 1970-01-01 00:00:00).
+        seed = std::chrono::system_clock::now().time_since_epoch().count();
     }
 
     // TODO FIXME - [CLi] handle loading, storing (and later optionally deleting) of radiosity cache file for trace abort & continue feature

--- a/source/base/image/metadata.h
+++ b/source/base/image/metadata.h
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2021 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -31,6 +31,8 @@
 ///
 /// @endparblock
 ///
+//------------------------------------------------------------------------------
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //******************************************************************************
 
 #ifndef POVRAY_BASE_METADATA_H
@@ -43,7 +45,6 @@
 #include <string>
 
 // Boost header files
-#include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 namespace pov_base

--- a/source/base/threadsafe.cpp
+++ b/source/base/threadsafe.cpp
@@ -1,0 +1,90 @@
+//******************************************************************************
+///
+/// @file base/threadsafe.cpp
+///
+/// Implementations related to thread-safe access to certain library functions.
+///
+/// The Functions in this file are essentially wrapper functions for a couple
+/// of standard C/C++ functions that are, by specification, not thread-safe.
+///
+/// The functions are designed for portability and robustness rather than
+/// performance, and should therefore be used sparingly.
+///
+/// @note
+///     Thread-safety of these functions is subject to the conditions that the
+///     underlying library functions are **only** invoked via these wrappers.
+///     Race conditions may still occur with threads invoking the underlying
+///     functions directly.
+///
+/// @copyright
+/// @parblock
+///
+/// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
+/// Copyright 1991-2021 Persistence of Vision Raytracer Pty. Ltd.
+///
+/// POV-Ray is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU Affero General Public License as
+/// published by the Free Software Foundation, either version 3 of the
+/// License, or (at your option) any later version.
+///
+/// POV-Ray is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU Affero General Public License for more details.
+///
+/// You should have received a copy of the GNU Affero General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+///
+/// ----------------------------------------------------------------------------
+///
+/// POV-Ray is based on the popular DKB raytracer version 2.12.
+/// DKBTrace was originally written by David K. Buck.
+/// DKBTrace Ver 2.0-2.12 were written by David K. Buck & Aaron A. Collins.
+///
+/// @endparblock
+///
+//------------------------------------------------------------------------------
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//******************************************************************************
+
+// Unit header file must be the first file included within POV-Ray *.cpp files (pulls in config)
+#include "base/threadsafe.h"
+
+// C++ variants of standard C header files
+#include <clocale>
+
+// Standard C++ header files
+#include <mutex>
+
+// this must be the last file included
+#include "base/povdebug.h"
+
+namespace pov_base
+{
+
+std::mutex gCtimeMutex;     /// Mutex for access to `<ctime>` thread-unsafe functions.
+std::mutex gLocaleMutex;    /// Mutex for calls to `setlocale`.
+
+void SafeGmtime(std::tm* result, const std::time_t* t)
+{
+    const std::lock_guard<std::mutex> lock(gCtimeMutex);
+    *result = *std::gmtime(t);
+}
+
+void SafeLocaltime(std::tm* result, const std::time_t* t)
+{
+    const std::lock_guard<std::mutex> lock(gCtimeMutex);
+    *result = *std::localtime(t);
+}
+
+void InitLocale()
+{
+    const std::lock_guard<std::mutex> lock(gLocaleMutex);
+    // Standard "C" locale for all aspects, except as amended further below.
+    // (NB: Since this is the standard C/C++ default, it shouldn't matter, but it also won't hurt.)
+    std::setlocale(LC_ALL, "C");
+    // User-preferred locale for date/time aspect.
+    std::setlocale(LC_TIME, "");
+}
+
+} // end of namespace

--- a/source/base/threadsafe.h
+++ b/source/base/threadsafe.h
@@ -1,0 +1,95 @@
+//******************************************************************************
+///
+/// @file base/threadsafe.h
+///
+/// Declarations related to thread-safe access to certain library functions.
+///
+/// The Functions in this file are essentially wrapper functions for a couple
+/// of standard C/C++ functions that are, by specification, not thread-safe.
+///
+/// The functions are designed for portability and robustness rather than
+/// performance, and should therefore be used sparingly.
+///
+/// @note
+///     Thread-safety of these functions is subject to the conditions that the
+///     underlying library functions are **only** invoked via these wrappers.
+///     Race conditions may still occur with threads invoking the underlying
+///     functions directly.
+///
+/// @copyright
+/// @parblock
+///
+/// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
+/// Copyright 1991-2021 Persistence of Vision Raytracer Pty. Ltd.
+///
+/// POV-Ray is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU Affero General Public License as
+/// published by the Free Software Foundation, either version 3 of the
+/// License, or (at your option) any later version.
+///
+/// POV-Ray is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU Affero General Public License for more details.
+///
+/// You should have received a copy of the GNU Affero General Public License
+/// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+///
+/// ----------------------------------------------------------------------------
+///
+/// POV-Ray is based on the popular DKB raytracer version 2.12.
+/// DKBTrace was originally written by David K. Buck.
+/// DKBTrace Ver 2.0-2.12 were written by David K. Buck & Aaron A. Collins.
+///
+/// @endparblock
+///
+//------------------------------------------------------------------------------
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//******************************************************************************
+
+#ifndef POVRAY_BASE_THREADSAFE_H
+#define POVRAY_BASE_THREADSAFE_H
+
+// Module config header file must be the first file included within POV-Ray unit header files
+#include "base/configbase.h"
+
+// C++ variants of standard C header files
+#include <ctime>
+
+
+namespace pov_base
+{
+
+//##############################################################################
+///
+/// @addtogroup PovBaseThreadsafe
+///
+/// @{
+
+/// Convert from `std::time_t` to `std::tm` using UTC representation.
+/// This is a thread-safe wrapper for `std::gmtime()` as defined in the `<ctime>` header.
+/// @attention
+///     The thread-safety of this function hinges on being the only entry point to the wrapped
+///     function.
+void SafeGmtime(std::tm* result, const std::time_t* t);
+
+/// Convert from `std::time_t` to `std::tm` using local time representation.
+/// This is a thread-safe wrapper for `std::localtime()` as defined in the `<ctime>` header.
+/// @attention
+///     The thread-safety of this function hinges on being the only entry point to the wrapped
+///     function.
+void SafeLocaltime(std::tm* result, const std::time_t* t);
+
+/// Initialize locale settings.
+/// @note
+///     Any POV-Ray application needs to call this function on startup to work properly.
+///     This is usually done by the back-end module function @ref povray_init().
+void InitLocale();
+
+/// @}
+///
+//##############################################################################
+
+} // end of namespace
+
+#endif // POVRAY_BASE_THREADSAFE_H

--- a/source/parser/parser.h
+++ b/source/parser/parser.h
@@ -33,6 +33,8 @@
 ///
 /// @endparblock
 ///
+//------------------------------------------------------------------------------
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //******************************************************************************
 
 #ifndef POVRAY_PARSER_PARSE_H
@@ -42,6 +44,7 @@
 #include "parser/configparser.h"
 
 #include <string>
+#include <chrono>
 
 #include "base/image/image.h"
 #include "base/messenger.h"
@@ -702,6 +705,10 @@ class Parser : public SceneTask
         bool Allow_Identifier_In_Call, Identifier_In_Call;
 
         size_t MaxCachedMacroSize;
+
+        using FractionalDays = std::chrono::duration<double, std::ratio<24 * 60 * 60>>;
+        std::chrono::system_clock::time_point mY2k;
+        bool localTime;
 
         // parse.h/parse.cpp
         void Frame_Init(void);

--- a/source/parser/parser_expressions.cpp
+++ b/source/parser/parser_expressions.cpp
@@ -45,9 +45,6 @@
 // Standard C++ header files
 #include <algorithm>
 
-// Boost header files
-#include <boost/date_time/posix_time/posix_time.hpp>
-
 // POV-Ray header files (base module)
 #include "base/fileinputoutput.h"
 #include "base/mathutil.h"
@@ -1112,45 +1109,7 @@ void Parser::Parse_Num_Factor (EXPRESS& Express,int *Terms)
                     break;
 
                 case NOW_TOKEN:
-                    {
-                        static boost::posix_time::ptime y2k(boost::gregorian::date(2000,1,1));
-                        boost::posix_time::ptime now(boost::posix_time::microsec_clock::universal_time());
-
-                        // Due to a bug in `boost::posix_time::microsec_clock::universal_time()`,
-                        // the value returned may actually be local time rather than UTC. We try to fix this
-                        // by comparing with `boost::posix_time::second_clock::universal_time()`, which is
-                        // less precise but more reliable in terms of time zone behavior.
-                        // (NB: While we could theoretically compute the offset once, and then re-use it every time
-                        // `new` is invoked, this would cause issues when rendering a scene during transition to or
-                        // from daylight savings time, or other events affecting the time zone. The current approach
-                        // is immune to such issues.)
-                        boost::posix_time::ptime lowPrecisionNow(boost::posix_time::second_clock::universal_time());
-                        // The difference between the two timers, rounded to quarters of an hour,
-                        // should correspond to the time zone offset (in seconds in this case).
-                        const auto tzPrecisionInSeconds = 15 * 60;
-                        int_least32_t tzOffset = std::lround(float((now - lowPrecisionNow).total_seconds()) / tzPrecisionInSeconds) * tzPrecisionInSeconds;
-                        // Unless someone paused the code in between the above statements, the resulting difference
-                        // should be our time zone offset in seconds (unless we're running on a system that's not
-                        // subject to the bug, in which case the resulting difference should be zero).
-                        if (tzOffset != 0)
-                        {
-                            if (sceneData->EffectiveLanguageVersion() < 380)
-                            {
-                                WarningOnce(kWarningGeneral, HERE,
-                                    "In POV-Ray v3.7, on some platforms 'now' erroneously evaluated to days since "
-                                    "2000-01-01 00:00 local time instead of UTC. For backward compatibility, this "
-                                    "bug is reproduced in legacy scenes, but the scene may produce different "
-                                    "results on other platforms.");
-                            }
-                            else
-                            {
-                                now -= boost::posix_time::time_duration(0, 0, tzOffset);
-                            }
-                        }
-
-                        const auto daysPerMicrosecond = 1.0e-6 / (24 * 60 * 60);
-                        Val = (now - y2k).total_microseconds() * daysPerMicrosecond;
-                    }
+                    Val = std::chrono::duration_cast<FractionalDays>(std::chrono::system_clock::now() - mY2k).count();
                     break;
             }
 

--- a/source/parser/parser_strings.cpp
+++ b/source/parser/parser_strings.cpp
@@ -8,7 +8,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2018 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2021 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -31,18 +31,24 @@
 ///
 /// @endparblock
 ///
+//------------------------------------------------------------------------------
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //******************************************************************************
 
 // Unit header file must be the first file included within POV-Ray *.cpp files (pulls in config)
 #include "parser/parser.h"
 
-// C++ variants of C standard header files
+// C++ variants of standard C header files
 #include <cctype>
 #include <cstdio>
 #include <cstdlib>
+#include <ctime>
 
-// Boost header files
-#include <boost/date_time/posix_time/posix_time.hpp>
+// Standard C++ header files
+#include <chrono>
+
+// POV-Ray header files (base module)
+#include "base/threadsafe.h"
 
 // POV-Ray header files (core module)
 #include "core/scene/scenedata.h"
@@ -468,25 +474,113 @@ UCS2 *Parser::Parse_Chr(bool /*pathname*/)
  *
 ******************************************************************************/
 
-#define PARSE_NOW_VAL_LENGTH 200
+static bool FindDatetimeFormatSpecifier(const char** list, const char* first, const char* last)
+{
+    POV_PARSER_ASSERT((*first != '\0') && (*last != '\0'));
+
+    if (first == last)
+        return (std::strchr(list[0], *first) != nullptr);
+
+    POV_PARSER_ASSERT(last - first == 1);
+
+    for (int i = 1; list[i] != nullptr; ++i)
+        if (list[i][0] == *first)
+            return (std::strchr(list[i] + 1, *last) != nullptr);
+
+    return false;
+}
 
 UCS2 *Parser::Parse_Datetime(bool pathname)
 {
+    // Enum representing a type of placeholder offense.
+    enum OffenseType { kNoOffense, kLocaleSensitive, kTimezoneSensitive, kLegacyNonPortable, kNonPortable, kIncomplete };
+    // Structure representing a placeholder and its offense.
+    struct Offense
+    {
+        // Offense, in ascending order of severity.
+        OffenseType type;
+        // Start of offending placeholder.
+        std::string field; // Offending placeholder
+        // Default Constructor.
+        Offense() : type(kNoOffense), field() {}
+        // Constructor.
+        Offense(OffenseType t, const char* first) : type(t), field(first) {}
+        // Constructor.
+        Offense(OffenseType t, const char* first, const char* last) : type(t), field(first, (last-first+1)) {}
+        // Overwrite data, provided other offense is more severe.
+        Offense& operator|=(const Offense& o) { if (o.type > type) { type = o.type; field = o.field; } return *this; }
+        // Convert to boolean
+        explicit operator bool() const { return type != kNoOffense; }
+    };
+
+    // Known prefixes of 2-character conversion specifiers.
+    // NB: `#` is a Microsoft extension.
+    static const char* knownPrefixes = "EO#";
+
+    // Conversion specifiers _guaranteed_ to be supported across _all_ platforms by specific versions of POV-Ray,
+    // as a nullptr-terminated list of strings.
+    // First string is a plain list of valid single-character specifiers; all other strings start with the respective
+    // prefix, followed by the corresponding list of valid secondary characters.
+    // NB: These lists should exactly match the set of conversion specifiers defined by the minimum C++ standard
+    // required to compile the respective version of POV-Ray.
+
+    // POV-Ray v3.8, which requires C++11.
+    static const char* portableFieldsCurrent[] {
+        "aAbBcCdDeFgGhHIjmMnprRStTuUVwWxXyYzZ%",
+        "EcCxXyY",
+        "OdeHImMSuUVwWy",
+        nullptr };
+    // POV-Ray v3.7, which required only C++03.
+    static const char* portableFieldsLegacy370[] {
+        "aAbBcdHIjmMpSUwWxXyYZ%",
+        nullptr };
+
+    // Conversion specifiers sensitive to time zone information (same format as above).
+    static const char* timezoneFields[] { "zZ", nullptr };
+
+    // Locale-independent conversion specifiers (same format as above).
+    // NB: The 2-character conversion specifiers defined in C/C++ are inherently locale-specific.
+    // NB: `z` qualifies in that its format is locale-independent, even though the value is not.
+    static const char* localeAgnosticFields[] { "CdDeFgGHIjmMnRStTuUVwWyYz%", nullptr };
+
+    // Fields that might evaluate to empty strings (same format as above).
+    // NB: `P` is a GNU extension.
+    static const char* potentiallyEmptyFields[] { "pPzZ", nullptr };
+
+    static constexpr int kMaxResultSize = 200; // Max number of chars in result, _including_ terminating NUL character.
+
     char *FormatStr = nullptr;
-    bool CallFree;
+    bool CallFree = false;
+
+    Offense offense;
+    void(*convertTime)(std::tm*, const std::time_t* time);
     int vlen = 0;
-    char val[PARSE_NOW_VAL_LENGTH + 1]; // Arbitrary size, usually a date format string is far less
+    char val[kMaxResultSize]; // Arbitrary size, usually a date format string is far less
 
     Parse_Paren_Begin();
 
-    std::time_t timestamp = floor((Parse_Float() + (365*30+7)) * 24*60*60 + 0.5);
+    if (localTime)
+    {
+        convertTime = &pov_base::SafeLocaltime;
+        FormatStr = "%Y-%m-%d %H:%M:%S%z";
+    }
+    else
+    {
+        convertTime = &pov_base::SafeGmtime;
+        FormatStr = "%Y-%m-%d %H:%M:%SZ";
+    }
+
+    const char** portableFieldsLegacy; // Fields reliably supported by whatever POV-Ray version is specified via `#version`.
+    if (sceneData->EffectiveLanguageVersion() < 380)
+        portableFieldsLegacy = portableFieldsLegacy370;
+    else
+        portableFieldsLegacy = nullptr; // skip legacy portability check
+
+    FractionalDays daysSinceY2k(Parse_Float());
     Parse_Comma();
     EXPECT_ONE
         CASE(RIGHT_PAREN_TOKEN)
             UNGET
-            CallFree = false;
-            // we use GMT as some platforms (e.g. windows) have different ideas of what to print when handling '%z'.
-            FormatStr = (char *)"%Y-%m-%d %H:%M:%SZ";
         END_CASE
 
         OTHERWISE
@@ -496,50 +590,205 @@ UCS2 *Parser::Parse_Datetime(bool pathname)
             if (FormatStr[0] == '\0')
             {
                 POV_FREE(FormatStr);
-                Error("Empty format string.");
+                Error("Empty 'datetime' format string.");
             }
-            if (strlen(FormatStr) > PARSE_NOW_VAL_LENGTH)
+            for (const char* pc = FormatStr; *pc != '\0'; ++pc)
             {
-                POV_FREE(FormatStr);
-                Error("Format string too long.");
+                // Skip over any non-placeholders.
+                if (*pc != '%')
+                    continue;
+
+                // Keep track of start of placeholder, so we can more easily report it
+                // in case it turns out to be offensive.
+                const char* po = pc;
+
+                if (*(++pc) == '\0')
+                {
+                    offense |= Offense(kIncomplete, po);
+                    break;
+                }
+
+                // Keep track of first "payload" character of placeholder.
+                const char* pc1 = pc;
+
+                // Check if we appear to have a two-character placeholder, and if so,
+                // advance to the next character.
+                if (std::strchr(knownPrefixes, *pc) != nullptr)
+                {
+                    if (*(++pc) == '\0')
+                    {
+                        offense |= Offense(kIncomplete, po);
+                        break;
+                    }
+                }
+
+                // NB: The next character should be the last one comprising the placeholder.
+
+                if (offense.type >= kNonPortable)
+                    continue; // We won't find any worse issue with this placeholder; next please.
+
+                // Check if placeholder is portable across all platforms for this version of POV-Ray.
+                if (!FindDatetimeFormatSpecifier(portableFieldsCurrent, pc1, pc))
+                    offense |= Offense(kNonPortable, po, pc);
+
+                if (offense.type >= kLegacyNonPortable)
+                    continue; // We won't find any worse issue with this placeholder; next please.
+
+                // Check if placeholder is portable across all platforms for the version the scene was designed for.
+                if ((portableFieldsLegacy != nullptr) && !FindDatetimeFormatSpecifier(portableFieldsLegacy, pc1, pc))
+                    offense |= Offense(kLegacyNonPortable, po, pc);
+
+                if (offense.type >= kTimezoneSensitive)
+                    continue; // We won't find any worse issue with this placeholder; next please.
+
+                // Check if placeholder requires time zone information that we might not have.
+                if (!localTime && FindDatetimeFormatSpecifier(timezoneFields, pc1, pc))
+                    offense |= Offense(kTimezoneSensitive, po, pc);
+
+                if (offense.type >= kLocaleSensitive)
+                    continue; // We won't find any worse issue with this placeholder; next please.
+
+                // Check if placeholder may have different format depending on locale.
+                if (!FindDatetimeFormatSpecifier(localeAgnosticFields, pc1, pc))
+                    offense |= Offense(kLocaleSensitive, po, pc);
+            }
+            switch (offense.type)
+            {
+                case kIncomplete:
+                    Error("Incomplete 'datetime' format placeholder ('%s').",
+                          offense.field.c_str());
+                    break;
+
+                case kNonPortable:
+                    WarningOnce(kWarningGeneral, HERE,
+                                "Scene uses 'datetime' format placeholder(s) that may not be supported on all "
+                                "platforms ('%s').",
+                                offense.field.c_str());
+                    break;
+
+                case kLegacyNonPortable:
+                    WarningOnce(kWarningGeneral, HERE,
+                                "Legacy scene uses 'datetime' format placeholder(s) that POV-Ray v%s "
+                                "did not support on all platforms ('%s').",
+                                sceneData->EffectiveLanguageVersion().str().c_str(),
+                                offense.field.c_str());
+                    break;
+
+                case kTimezoneSensitive:
+                    WarningOnce(kWarningGeneral, HERE,
+                                "Scene uses 'datetime' format placeholder(s) relating to time zone information "
+                                "('%s') without 'local_time' global setting turned on, implying UTC mode of "
+                                "operation. On some systems, this may cause the placeholder(s) to not work as "
+                                "expected.",
+                                offense.field.c_str());
+                    break;
+
+                case kLocaleSensitive:
+                    WarningOnce(kWarningGeneral, HERE,
+                                "Scene uses 'datetime' format placeholder(s) that may produce "
+                                "different results depending on system locale settings ('%s').",
+                                offense.field.c_str());
+                    break;
+
+                case kNoOffense:
+                    break;
             }
         END_CASE
     END_EXPECT
 
     Parse_Paren_End();
 
-    // NB don't wrap only the call to strftime() in the try, because visual C++ will, in release mode,
-    // optimize the try/catch away since it doesn't believe that the RTL can throw exceptions. since
+    // NB don't wrap only the call to strftime() in the try, because Visual C++ will, in release mode,
+    // optimize the try/catch away since it doesn't believe that the RTL can throw exceptions. Since
     // the windows version of POV hooks the invalid parameter handler RTL callback and throws an exception
     // if it's called, they can.
     try
     {
-        std::tm t = boost::posix_time::to_tm(boost::posix_time::from_time_t(timestamp));
-        // TODO FIXME - we should either have this locale setting globally, or avoid it completely; in either case it shouldn't be *here*.
-        setlocale(LC_TIME,""); // Get the local preferred format
-        vlen = strftime(val, PARSE_NOW_VAL_LENGTH, FormatStr, &t);
+        auto timeSinceY2k = std::chrono::duration_cast<std::chrono::system_clock::duration>(daysSinceY2k);
+        auto timeToPrint = mY2k + timeSinceY2k;
+        std::time_t timestamp = std::chrono::system_clock::to_time_t(timeToPrint);
+
+        std::tm t;
+        convertTime(&t, &timestamp);
+
+        vlen = std::strftime(val, kMaxResultSize, FormatStr, &t);
+
+        if (vlen == 0)
+        {
+            // As per the the C/C++ standard, a `strftime` return value of zero _per se_ may not
+            // necessarily indicate an error: The resulting string could simply be empty due to
+            // the format consisting of only conversion specifiers that happen to evaluate to
+            // empty strings for the current locale (e.g. `%p`).
+
+            // We employ some strong logics as well as weaker heuristics to figure out whether
+            // this is definitely an error; in that case, we report it to code further downstream
+            // by setting the length value to the buffer size (which also happens to be how
+            // libc 4.4.1 and earlier reported overflow), which can never happen in case of a
+            // success.
+
+            // TODO - we could avoid this whole mess by simply injecting some arbitrary character
+            // at the start or end of the format string, and cut it away again after the
+            // conversion. That way, even an "empty" string would give us at least 1 character.
+
+            if (val[0] != '\0')
+            {
+                // In absence of an non-error, the result string would have to be empty,
+                // but that's not what we're seeing here, confirming that this is indeed
+                // unambiguously an error.
+                vlen = kMaxResultSize;
+            }
+            else
+            {
+                // Check if the result string could conceivably be empty.
+                for (const char* pc = FormatStr; *pc != '\0'; ++pc)
+                {
+                    if (*pc != '%')
+                    {
+                        // Any non-placeholder character would have to be copied verbatim,
+                        // and should therefore have resulted in a non-empty string.
+                        vlen = kMaxResultSize;
+                        break;
+                    }
+                    ++pc;
+                    const char* pc1 = pc;
+                    if (std::strchr(knownPrefixes, *pc) != nullptr)
+                        ++pc;
+                    if (!FindDatetimeFormatSpecifier(potentiallyEmptyFields, pc1, pc))
+                    {
+                        // Placeholder is not in the list of those we expect to be replaced with empty strings.
+                        vlen = kMaxResultSize;
+                        break;
+                    }
+                }
+            }
+        }
     }
     catch (pov_base::Exception& e)
     {
-        // the windows version of strftime calls the invalid parameter handler if
-        // it gets a bad format string. this will in turn raise an exception of type
-        // kParamErr. if the exception isn't that, allow normal exception processing
+        // The windows version of `strftime` calls the invalid parameter handler if
+        // it gets a bad format string. This will in turn raise an exception of type
+        // `kParamErr`. If the exception isn't that, allow normal exception processing
         // to continue, otherwise we issue a more useful error message.
         if ((e.codevalid() == false) || (e.code() != kParamErr))
             throw;
-        vlen = 0;
+        Error("Invalid 'datetime' format placeholder");
     }
-    if (vlen == PARSE_NOW_VAL_LENGTH) // on error: max for libc 4.4.1 & before
-        vlen = 0; // return an empty string on error (content of val[] is undefined)
-    val[vlen]='\0'; // whatever, that operation is now safe (and superfluous except for error)
-
     if (CallFree)
-    {
         POV_FREE(FormatStr);
-    }
+
+    if (vlen == kMaxResultSize)
+        // Unambiguous error
+        Error("Invalid 'datetime' format placeholder, or resulting string too long (>%i characters).",
+              kMaxResultSize - 1);
 
     if (vlen == 0)
-        Error("Invalid formatting code in format string, or resulting string too long.");
+    {
+        // Maybe an error, maybe just an empty result string
+        PossibleError("'datetime' result string empty; if this is unexpected, check for "
+                      "invalid 'datetime' format placeholders, or whether the resulting "
+                      "string would have been too long (>%i characters).",
+                      kMaxResultSize - 1);
+    }
 
     return String_To_UCS2(val);
 }

--- a/source/parser/reservedwords.cpp
+++ b/source/parser/reservedwords.cpp
@@ -33,6 +33,8 @@
 ///
 /// @endparblock
 ///
+//------------------------------------------------------------------------------
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //******************************************************************************
 
 // Unit header file must be the first file included within POV-Ray *.cpp files (pulls in config)
@@ -304,6 +306,7 @@ const RESERVED_WORD Reserved_Words[] = {
     { LN_TOKEN,                     "ln" },
     { LOAD_FILE_TOKEN,              "load_file" },
     { LOCAL_TOKEN,                  "local" },
+    { LOCAL_TIME_TOKEN,             "local_time",               380 },
     { LOCATION_TOKEN,               "location" },
     { LOG_TOKEN,                    "log" },
     { LOOK_AT_TOKEN,                "look_at" },

--- a/source/parser/reservedwords.h
+++ b/source/parser/reservedwords.h
@@ -32,6 +32,8 @@
 ///
 /// @endparblock
 ///
+//------------------------------------------------------------------------------
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //******************************************************************************
 
 #ifndef POVRAY_PARSER_RESERVEDWORDS_H
@@ -443,6 +445,7 @@ enum TOKEN_IDS
     LINEAR_SWEEP_TOKEN,
     LOAD_FILE_TOKEN,
     LOCAL_TOKEN,
+    LOCAL_TIME_TOKEN,
     LOCATION_TOKEN,
     LOOK_AT_TOKEN,
     LOOKS_LIKE_TOKEN,

--- a/windows/pvengine.cpp
+++ b/windows/pvengine.cpp
@@ -10,7 +10,7 @@
 /// @parblock
 ///
 /// Persistence of Vision Ray Tracer ('POV-Ray') version 3.8.
-/// Copyright 1991-2017 Persistence of Vision Raytracer Pty. Ltd.
+/// Copyright 1991-2021 Persistence of Vision Raytracer Pty. Ltd.
 ///
 /// POV-Ray is free software: you can redistribute it and/or modify
 /// it under the terms of the GNU Affero General Public License as
@@ -33,6 +33,8 @@
 ///
 /// @endparblock
 ///
+//------------------------------------------------------------------------------
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //******************************************************************************
 
 /// @file
@@ -93,6 +95,8 @@
 #endif
 
 #include "cpuid.h"
+
+#include "base/threadsafe.h"
 
 #ifdef TRY_OPTIMIZED_NOISE
 // TODO - This is a hack; we should get the noise generator choice information via POVMS from the back-end.
@@ -776,8 +780,10 @@ void PrintRenderTimes (int Finished, int NormalCompletion)
           char fn[_MAX_PATH];
           char ts[256];
           time_t t = time(NULL);
-
-          strftime(ts, sizeof(ts), "%Y%m%d.%H%M%S", gmtime(&t));
+          std::tm tm;
+          _locale_t loc = _create_locale(LC_TIME, "C");
+          pov_base::SafeGmtime(&tm, &t);
+          _strftime_l(ts, sizeof(ts), "%Y%m%d.%H%M%S", &tm, loc);
           sprintf(fn, "%sbenchmark-%s.txt", DocumentsPath, ts);
           FILE *f = fopen(fn, "wt");
           if (f != NULL)
@@ -785,7 +791,7 @@ void PrintRenderTimes (int Finished, int NormalCompletion)
             int n = Get_Benchmark_Version();
 
             fprintf(f, "%s", str);
-            strftime(str, sizeof(str), "%#c", gmtime(&t));
+            _strftime_l(str, sizeof(str), "%#c", &tm, loc);
             fprintf(f, "\nRender of benchmark version %x.%02x completed at %s UTC.\n", n / 256, n % 256, str);
             fprintf(f, "----------------------------------------------------------------------------\n");
             GenerateDumpMeta(true);


### PR DESCRIPTION
- Added `local_time BOOL` global setting, defaulting to `off`; when set to `on`, `datetime` will now report local time instead of UTC.
- `datetime` will now sanity-check the specified format string (unless the default is used), and generate various warnings if applicable.
- `datetime` will now try to distinguish between a genuine error, a and non-error situation in which the result string just happens to be empty.
- `LC_TIME` locale is now set someplace more sane.

Also, pushed back on the use of boost date_time library in favor of C++11 features.