### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ At this point in time, the only platform for which the project distributes pre-b
 obtained via http://www.povray.org/download/. We do intend to provide Mac OS X
 binaries shortly, but these will be console-mode only (based on the unix build).
 
-Official Windows binaries of selected development versions are made availabe at
+Official Windows binaries of selected development versions are made available at
 https://github.com/POV-Ray/povray/releases on a semi-irregular basis.
 
 Building POV-Ray

--- a/source/frontend/configfrontend.h
+++ b/source/frontend/configfrontend.h
@@ -81,7 +81,7 @@
 #endif
 
 /// @def DEFAULT_DISPLAY_GAMMA
-/// Gamma curve numerial parameter.
+/// Gamma curve numerical parameter.
 ///
 /// If @ref DEFAULT_DISPLAY_GAMMA_TYPE is set to @ref kPOVList_GammaType_PowerLaw,
 /// this is the overall effective gamma of the display system.

--- a/source/frontend/renderfrontend.cpp
+++ b/source/frontend/renderfrontend.cpp
@@ -241,7 +241,7 @@ RenderFrontendBase::SceneId RenderFrontendBase::CreateScene(SceneData& shd, POVM
         if(obj.Exist(kPOVAttrib_AllConsole))
         {
             bool b = obj.GetBool(kPOVAttrib_AllConsole);
-            // NEVERE disable copyright banner BANNER_STREAM stream! [trf]
+            // NEVER disable copyright banner BANNER_STREAM stream! [trf]
             shd.consoleoutput[DEBUG_STREAM] = b;
             shd.consoleoutput[FATAL_STREAM] = b;
             shd.consoleoutput[RENDER_STREAM] = b;

--- a/source/frontend/shelloutprocessing.cpp
+++ b/source/frontend/shelloutprocessing.cpp
@@ -651,7 +651,7 @@ bool ShelloutProcessing::KillShellouts(int timeout, bool force)
 // you should reap any processes in your destructor in case CollectCommand doesn't
 // get called.
 //
-// if the platform implemeting a subclass of this method has the equivalent of a
+// if the platform implementing a subclass of this method has the equivalent of a
 // system log (e.g. syslog on unix, event log on windows), the implementation should
 // consider providing a user-controllable option to log any commands using such.
 bool ShelloutProcessing::ExecuteCommand(const std::string& cmd, const std::string& params)

--- a/source/frontend/shelloutprocessing.h
+++ b/source/frontend/shelloutprocessing.h
@@ -303,7 +303,7 @@ protected:
     // you should reap any processes in your destructor in case CollectCommand doesn't
     // get called.
     //
-    // if the platform implemeting a subclass of this method has the equivalent of a
+    // if the platform implementing a subclass of this method has the equivalent of a
     // system log (e.g. syslog on unix, event log on windows), the implementation should
     // consider providing a user-controllable option to log any commands using such.
     virtual bool ExecuteCommand(const std::string& cmd, const std::string& params);

--- a/source/parser/fncode.cpp
+++ b/source/parser/fncode.cpp
@@ -498,7 +498,7 @@ void FNCode::SetFlag(unsigned int flag, char *str)
 *
 * DESCRIPTION
 *
-*   Compiles an expression (sub-) tree recursivly.
+*   Compiles an expression (sub-) tree recursively.
 *
 * CHANGES
 *
@@ -1181,7 +1181,7 @@ void FNCode::compile_select(ExprNode *expr)
 * INPUT
 *
 *   expr - list of function parameters
-*   op - operation to perfrom on value and result for each step
+*   op - operation to perform on value and result for each step
 *   neutral - neutral element of the operation to apply
 *
 * OUTPUT

--- a/source/parser/parser.cpp
+++ b/source/parser/parser.cpp
@@ -619,7 +619,7 @@ void Parser::Destroy_Frame()
     // This is necessary as a user who hits CANCEL during any IO performed
     // by this routine (e.g. Destroy_Object(), which can complain about
     // isosurface max_gradient), will cause this routine to be entered again
-    // before the relevent data member has been set to `nullptr` (this is able
+    // before the relevant data member has been set to `nullptr` (this is able
     // to happen since cancel will invoke a longjmp on most platforms).
     // This causes the currently-executing segment to be destroyed twice,
     // which is a Bad Thing(tm). [CJC 11/01]
@@ -8868,12 +8868,12 @@ void Parser::Link_Textures (TEXTURE **Old_Textures, TEXTURE *New_Textures)
     }
     for (Layer = New_Textures; Layer->Next != nullptr; Layer = Layer->Next)
     {
-        /* NK layers - 1999 June 10 - for backwards compatiblity with layered textures */
+        /* NK layers - 1999 June 10 - for backwards compatibility with layered textures */
         if(sceneData->EffectiveLanguageVersion() <= 310)
             Convert_Filter_To_Transmit(Layer->Pigment);
     }
 
-    /* NK layers - 1999 Nov 16 - for backwards compatiblity with layered textures */
+    /* NK layers - 1999 Nov 16 - for backwards compatibility with layered textures */
     if ((sceneData->EffectiveLanguageVersion() <= 310) && (*Old_Textures != nullptr))
         Convert_Filter_To_Transmit(Layer->Pigment);
 

--- a/source/parser/parser_expressions.cpp
+++ b/source/parser/parser_expressions.cpp
@@ -2265,7 +2265,7 @@ void Parser::Parse_Colour (RGBFTColour& colour, bool expectFT)
             {
                 // Note: Setting up for potential warning on single value float promote to
                 // five value color vector. Any single float will be promoted to the full
-                // 'tgtTerms' value. This usually results in filter and trasmit values >0,
+                // 'tgtTerms' value. This usually results in filter and transmit values >0,
                 // which caused shadow artifacts back to at least version v3.6.1.
                 if ((CurrentCategorizedTokenId() == FLOAT_TOKEN_CATEGORY) || (CurrentTrueTokenId() == FUNCT_ID_TOKEN))
                     sawFloatOrFloatFnct = true;
@@ -2861,7 +2861,7 @@ template TextureBlendMapPtr Parser::Parse_Blend_List<TextureBlendMap>   (int Cou
 *
 * DESCRIPTION
 *
-*   This performs a similar funciton to Parse_Blend_List.  It was created
+*   This performs a similar function to Parse_Blend_List.  It was created
 *   specifically for uv mapping.  It is different from Parse_Blend_List in
 *   the following ways:
 *     It will parse exactly one item (normal,pigment, or texture).

--- a/source/parser/parser_functions.cpp
+++ b/source/parser/parser_functions.cpp
@@ -499,7 +499,7 @@ ExprNode *Parser::new_expr_node(int stage, int op)
 *
 * INPUT
 *
-*   current - current poistion in expression tree
+*   current - current position in expression tree
 *   stage - stage/precedence of operation
 *   op - operation
 *
@@ -537,7 +537,7 @@ bool Parser::expr_noop(ExprNode *&, int, int)
 *
 * INPUT
 *
-*   current - current poistion in expression tree
+*   current - current position in expression tree
 *   stage - stage/precedence of operation
 *   op - operation
 *
@@ -635,7 +635,7 @@ bool Parser::expr_grow(ExprNode *&current, int stage, int op)
 *
 * INPUT
 *
-*   current - current poistion in expression tree
+*   current - current position in expression tree
 *   stage - stage/precedence of operation
 *   op - operation
 *
@@ -710,7 +710,7 @@ bool Parser::expr_call(ExprNode *&current, int stage, int op)
 *
 * INPUT
 *
-*   current - current poistion in expression tree
+*   current - current position in expression tree
 *   stage - stage/precedence of operation
 *   op - operation
 *
@@ -771,7 +771,7 @@ bool Parser::expr_put(ExprNode *&current, int stage, int op)
 *
 * INPUT
 *
-*   current - current poistion in expression tree
+*   current - current position in expression tree
 *   stage - stage/precedence of operation
 *   op - operation
 *
@@ -820,7 +820,7 @@ bool Parser::expr_new(ExprNode *&current, int /*stage*/, int /*op*/)
 *
 * INPUT
 *
-*   current - current poistion in expression tree
+*   current - current position in expression tree
 *   stage - stage/precedence of operation
 *   op - operation
 *
@@ -861,7 +861,7 @@ bool Parser::expr_ret(ExprNode *&, int, int)
 *
 * INPUT
 *
-*   current - current poistion in expression tree
+*   current - current position in expression tree
 *   stage - stage/precedence of operation
 *   op - operation
 *

--- a/windows/pvbitmap.cpp
+++ b/windows/pvbitmap.cpp
@@ -531,7 +531,7 @@ HPALETTE CreateDIBPalette(HDIB hDIB)
  *
  * NOTE:
  *
- * The bitmap returned from this funciton is always a bitmap compatible
+ * The bitmap returned from this function is always a bitmap compatible
  * with the screen (e.g. same bits/pixel and color planes) rather than
  * a bitmap with the same attributes as the DIB.  This behavior is by
  * design, and occurs because this function calls CreateDIBitmap to


### PR DESCRIPTION
Found via `codespell -q 3 -S "./libraries" -L ans,feld,medias,nd,pary,pres,sie,thn,writen`