### PR TITLE
Apply translate and rotate to user_defined cameras.

### DIFF
--- a/source/core/render/tracepixel.cpp
+++ b/source/core/render/tracepixel.cpp
@@ -873,32 +873,51 @@ bool TracePixel::CreateCameraRay(Ray& ray, DBL x, DBL y, DBL width, DBL height, 
             break;
 
         case USER_DEFINED_CAMERA:
-            // Convert the x coordinate to be a DBL from -0.5 to 0.5.
-            x0 = x / width - 0.5;
-
-            // Convert the y coordinate to be a DBL from -0.5 to 0.5.
-            y0 = 0.5 - y / height;
-
-            for (unsigned int i = 0; i < 3; ++i)
             {
-                if (camera.Location_Fn[i] != nullptr)
-                    cameraLocation[i] = mpCameraLocationFn[i]->Evaluate(x0, y0);
-                if (!IsFinite(cameraLocation[i]))
+                // Convert the x coordinate to be a DBL from -0.5 to 0.5.
+                x0 = x / width - 0.5;
+
+                // Convert the y coordinate to be a DBL from -0.5 to 0.5.
+                y0 = 0.5 - y / height;
+
+                bool bLocationFunction = false;
+                bool bDirectionFunction = false;
+
+                for (unsigned int i = 0; i < 3; ++i)
+                {
+                    if (camera.Location_Fn[i] != nullptr)
+                    {
+                        cameraLocation[i] = mpCameraLocationFn[i]->Evaluate(x0, y0);
+                        bLocationFunction = true;
+                    }
+                    if (!IsFinite(cameraLocation[i]))
+                        return false;
+
+                    if (camera.Direction_Fn[i] != nullptr)
+                    {
+                        cameraDirection[i] = mpCameraDirectionFn[i]->Evaluate(x0, y0);
+                        bDirectionFunction = true;
+                    }
+                    if (!IsFinite(cameraDirection[i]))
+                        return false;
+                }
+
+                if (bLocationFunction)
+                    MTransPoint(cameraLocation, cameraLocation, camera.UserTrans);
+
+                if (bDirectionFunction)
+                    MTransDirection(cameraDirection, cameraDirection, camera.UserTrans);
+
+                if (cameraDirection.IsNearNull(EPSILON))
                     return false;
-                if (camera.Direction_Fn[i] != nullptr)
-                    cameraDirection[i] = mpCameraDirectionFn[i]->Evaluate(x0, y0);
-                if (!IsFinite(cameraDirection[i]))
-                    return false;
+                ray.Origin    = cameraLocation;
+                ray.Direction = cameraDirection;
+
+                if(useFocalBlur)
+                    JitterCameraRay(ray, x, y, ray_number);
+
+                InitRayContainerState(ray, true);
             }
-            if (cameraDirection.IsNearNull(EPSILON))
-                return false;
-            ray.Origin    = cameraLocation;
-            ray.Direction = cameraDirection;
-
-            if(useFocalBlur)
-                JitterCameraRay(ray, x, y, ray_number);
-
-            InitRayContainerState(ray, true);
             break;
 
         default:

--- a/source/core/scene/camera.cpp
+++ b/source/core/scene/camera.cpp
@@ -75,7 +75,10 @@ namespace pov
 
 void Camera::Translate(const Vector3d& Vector)
 {
-    Location += Vector;
+    TRANSFORM Trans;
+
+    Compute_Translation_Transform(&Trans, Vector);
+    Transform(&Trans);
 }
 
 
@@ -183,7 +186,9 @@ void Camera::Transform(const TRANSFORM *Trans)
     MTransPoint(Location, Location, Trans);
     MTransDirection(Direction, Direction, Trans);
     MTransDirection(Up, Up, Trans);
-    MTransDirection(Right, Right, Trans);
+    MTransDirection(Right, Right, Trans);  
+    
+    Compose_Transforms (UserTrans, Trans);
 }
 
 
@@ -257,6 +262,8 @@ void Camera::Init()
         Location_Fn[i]  = nullptr;
         Direction_Fn[i] = nullptr;
     }
+
+    UserTrans = Create_Transform();
 }
 
 /*****************************************************************************
@@ -384,6 +391,10 @@ Camera& Camera::operator=(const Camera& src)
 
     }
 
+    if (UserTrans != nullptr)
+        Destroy_Transform(UserTrans);
+    UserTrans = (src.UserTrans ? Copy_Transform(src.UserTrans) : nullptr);
+
     return *this;
 }
 
@@ -397,6 +408,7 @@ Camera::Camera(const Camera& src)
         Location_Fn[i]  = nullptr;
         Direction_Fn[i] = nullptr;
     }
+    UserTrans = nullptr;
     operator=(src);
 }
 
@@ -441,6 +453,7 @@ Camera::~Camera()
         if (Direction_Fn[i] != nullptr)
             delete Direction_Fn[i];
     }
+    Destroy_Transform(UserTrans);
 }
 
 }

--- a/source/core/scene/camera.h
+++ b/source/core/scene/camera.h
@@ -100,6 +100,7 @@ public:
     PIGMENT *Bokeh;                 // Pigment to use for the bokeh
     GenericScalarFunctionPtr Location_Fn[3];  // [USER_DEFINED_CAMERA] Set of functions defining the ray's origin for each screen position.
     GenericScalarFunctionPtr Direction_Fn[3]; // [USER_DEFINED_CAMERA] Set of functions defining the ray's direction for each screen position.
+    TRANSFORM *UserTrans;           // [USER_DEFINED_CAMERA] Transformation to apply after calculating functions
 
     // the following declarations are used for the mesh camera
     unsigned int Face_Distribution_Method;  // how to associate a pixel to a face within a mesh


### PR DESCRIPTION
user_defined cameras don't apply transformations to the user defined functions.  This makes them more difficult to work with when moving the camera.  This commit will apply transformations, if present, after the user defined functions.

You can see some discussion of the issue here.  It can be worked around.  For rotations, the work around makes the user defined functions much more complicated.

http://news.povray.org/povray.general/thread/%3CXnsA9E3A3F647A49seed7%40news.povray.org%3E/
http://news.povray.org/povray.binaries.images/thread/%3C5cec7461%40news.povray.org%3E/

The patch creates a transform in the camera to store the transformations as they are applied to the camera.  When the rays are calculated, the user defined function is applied first, followed by the transform.