### PR TITLE
remove unecessary nullptr check before 'delete' and 'delete[]'

### DIFF
--- a/libraries/openexr/IlmImf/ImfDeepScanLineInputFile.cpp
+++ b/libraries/openexr/IlmImf/ImfDeepScanLineInputFile.cpp
@@ -191,8 +191,7 @@ LineBuffer::LineBuffer ():
 
 LineBuffer::~LineBuffer ()
 {
-    if (compressor != 0)
-        delete compressor;
+    delete compressor;
 }
 
 } // namespace
@@ -295,14 +294,12 @@ DeepScanLineInputFile::Data::Data (int numThreads):
 DeepScanLineInputFile::Data::~Data ()
 {
     for (size_t i = 0; i < lineBuffers.size(); i++)
-        if (lineBuffers[i] != 0)
-            delete lineBuffers[i];
+        delete lineBuffers[i];
 
     for (size_t i = 0; i < slices.size(); i++)
         delete slices[i];
 
-    if (sampleCountTableComp != 0)
-        delete sampleCountTableComp;
+    delete sampleCountTableComp;
     
     if (multiPartBackwardSupport)
         delete multiPartFile;
@@ -513,7 +510,7 @@ readPixelData (InputStreamMutex *streamData,
     {
         // (TODO) check if the packed data size is too big?
         // (TODO) better memory management. Don't delete buffer all the time.
-        if (buffer != 0) delete[] buffer;
+        delete[] buffer;
         buffer = new char[packedDataSize];
         streamData->is->read (buffer, packedDataSize);
     }
@@ -612,8 +609,7 @@ LineBufferTask::execute ()
             // (TODO) optimize this. don't do this every time.
             //
 
-            if (_lineBuffer->compressor != 0)
-                delete _lineBuffer->compressor;
+            delete _lineBuffer->compressor;
             Int64 maxBytesPerLine = 0;
             for (int i = _lineBuffer->minY - _ifd->minY;
                  i <= maxY - _ifd->minY;
@@ -975,9 +971,9 @@ DeepScanLineInputFile::DeepScanLineInputFile
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
-        if (is)          delete is;
-        if (_data && _data->_streamData) delete _data->_streamData;
-        if (_data)       delete _data;
+        delete is;
+        if (_data) delete _data->_streamData;
+        delete _data;
 
         REPLACE_EXC (e, "Cannot read image file "
                         "\"" << fileName << "\". " << e);
@@ -985,9 +981,9 @@ DeepScanLineInputFile::DeepScanLineInputFile
     }
     catch (...)
     {
-        if (is)          delete is;
-        if (_data && _data->_streamData) delete _data->_streamData;
-        if (_data)       delete _data;
+        delete is;
+        if (_data) delete _data->_streamData;
+        delete _data;
 
         throw;
     }
@@ -1755,10 +1751,7 @@ void DeepScanLineInputFile::readPixelSampleCounts (const char* rawPixelData,
         }
     }
     
-    if(decomp)
-    {
-       delete decomp;
-    }
+    delete decomp;
 }
 
 

--- a/libraries/openexr/IlmImf/ImfDeepScanLineOutputFile.cpp
+++ b/libraries/openexr/IlmImf/ImfDeepScanLineOutputFile.cpp
@@ -180,11 +180,8 @@ LineBuffer::LineBuffer (int linesInBuffer) :
 
 LineBuffer::~LineBuffer ()
 {
-    if (compressor != 0)
-        delete compressor;
-
-    if (sampleCountTableCompressor != 0)
-        delete sampleCountTableCompressor;
+    delete compressor;
+    delete sampleCountTableCompressor;
 }
 
 } // namespace
@@ -265,8 +262,7 @@ DeepScanLineOutputFile::Data::Data (int numThreads):
 DeepScanLineOutputFile::Data::~Data ()
 {
     for (size_t i = 0; i < lineBuffers.size(); i++)
-        if (lineBuffers[i] != 0)
-            delete lineBuffers[i];
+        delete lineBuffers[i];
 
     for (size_t i = 0; i < slices.size(); i++)
         delete slices[i];
@@ -752,8 +748,7 @@ LineBufferTask::execute ()
         //
 
         // (TODO) don't do this all the time.
-        if (_lineBuffer->compressor != 0)
-            delete _lineBuffer->compressor;
+        delete _lineBuffer->compressor;
         _lineBuffer->compressor = newCompressor (_ofd->header.compression(),
                                                  maxBytesPerLine,
                                                  _ofd->header);
@@ -951,8 +946,7 @@ DeepScanLineOutputFile::initialize (const Header &header)
                                             _data->header);
     _data->format = defaultFormat (compressor);
     _data->linesInBuffer = numLinesInBuffer (compressor);
-    if (compressor != 0)
-        delete compressor;
+    delete compressor;
 
     int lineOffsetSize = (_data->maxY - _data->minY +
                           _data->linesInBuffer) / _data->linesInBuffer;

--- a/libraries/openexr/IlmImf/ImfDeepTiledInputFile.cpp
+++ b/libraries/openexr/IlmImf/ImfDeepTiledInputFile.cpp
@@ -440,7 +440,7 @@ readTileData (InputStreamMutex *streamData,
     {
         // (TODO) check if the packed data size is too big?
         // (TODO) better memory management here. Don't delete buffer everytime.
-        if (buffer != 0) delete[] buffer;
+        delete[] buffer;
         buffer = new char[dataSize];
         streamData->is->read (buffer, dataSize);
     }
@@ -611,8 +611,7 @@ TileBufferTask::execute ()
         }
 
         // (TODO) don't do this every time.
-        if (_tileBuffer->compressor != 0)
-            delete _tileBuffer->compressor;
+        delete _tileBuffer->compressor;
         _tileBuffer->compressor = newTileCompressor
                                   (_ifd->header.compression(),
                                    maxBytesPerTileLine,
@@ -824,9 +823,9 @@ DeepTiledInputFile::DeepTiledInputFile (const char fileName[], int numThreads):
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
-        if (is)          delete is;
-        if (_data && !_data->multiPartBackwardSupport && _data->_streamData) delete _data->_streamData;
-        if (_data)       delete _data;
+        delete is;
+        if (_data && !_data->multiPartBackwardSupport) delete _data->_streamData;
+        delete _data;
 
         REPLACE_EXC (e, "Cannot open image file "
                         "\"" << fileName << "\". " << e);
@@ -834,9 +833,9 @@ DeepTiledInputFile::DeepTiledInputFile (const char fileName[], int numThreads):
     }
     catch (...)
     {
-        if (is)          delete is;
-        if (_data && !_data->multiPartBackwardSupport && _data->_streamData) delete _data->_streamData;
-        if (_data)       delete _data;
+        delete is;
+        if (_data && !_data->multiPartBackwardSupport) delete _data->_streamData;
+        delete _data;
 
         throw;
     }
@@ -879,8 +878,8 @@ DeepTiledInputFile::DeepTiledInputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream 
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
-        if (_data && !_data->multiPartBackwardSupport && _data->_streamData) delete _data->_streamData;
-        if (_data)       delete _data;
+        if (_data && !_data->multiPartBackwardSupport) delete _data->_streamData;
+        delete _data;
 
         REPLACE_EXC (e, "Cannot open image file "
                         "\"" << is.fileName() << "\". " << e);
@@ -888,8 +887,8 @@ DeepTiledInputFile::DeepTiledInputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream 
     }
     catch (...)
     {
-        if (_data && !_data->multiPartBackwardSupport && _data->_streamData) delete _data->_streamData;
-        if (_data)       delete _data;
+        if (_data && !_data->multiPartBackwardSupport) delete _data->_streamData;
+        delete _data;
 
         throw;
     }
@@ -1052,8 +1051,7 @@ DeepTiledInputFile::~DeepTiledInputFile ()
 {
     if (!_data->memoryMapped)
         for (size_t i = 0; i < _data->tileBuffers.size(); i++)
-            if (_data->tileBuffers[i]->buffer != 0)
-                delete [] _data->tileBuffers[i]->buffer;
+            delete [] _data->tileBuffers[i]->buffer;
 
     if (_data->_deleteStream)
         delete _data->_streamData->is;

--- a/libraries/openexr/IlmImf/ImfDeepTiledOutputFile.cpp
+++ b/libraries/openexr/IlmImf/ImfDeepTiledOutputFile.cpp
@@ -252,11 +252,8 @@ TileBuffer::TileBuffer ():
 
 TileBuffer::~TileBuffer ()
 {
-    if (compressor != 0)
-        delete compressor;
-
-    if (sampleCountTableCompressor != 0)
-        delete sampleCountTableCompressor;
+    delete compressor;
+    delete sampleCountTableCompressor;
 }
 
 
@@ -993,8 +990,7 @@ TileBufferTask::execute ()
         _tileBuffer->dataPtr = _tileBuffer->buffer;
 
         // (TODO) don't do this all the time.
-        if (_tileBuffer->compressor != 0)
-            delete _tileBuffer->compressor;
+        delete _tileBuffer->compressor;
         _tileBuffer->compressor = newTileCompressor
                                     (_ofd->header.compression(),
                                      maxBytesPerTileLine,
@@ -1074,9 +1070,9 @@ DeepTiledOutputFile::DeepTiledOutputFile
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
-        if (_data && _data->_streamData && _data->_streamData->os) delete _data->_streamData->os;
-        if (_data && _data->_streamData)     delete _data->_streamData;
-        if (_data)           delete _data;
+        if (_data && _data->_streamData) delete _data->_streamData->os;
+        if (_data)  delete _data->_streamData;
+        delete _data;
 
         REPLACE_EXC (e, "Cannot open image file "
                         "\"" << fileName << "\". " << e);
@@ -1084,9 +1080,9 @@ DeepTiledOutputFile::DeepTiledOutputFile
     }
     catch (...)
     {
-        if (_data && _data->_streamData && _data->_streamData->os) delete _data->_streamData->os;
-        if (_data->_streamData)     delete _data->_streamData;
-        if (_data)           delete _data;
+        if (_data && _data->_streamData) delete _data->_streamData->os;
+        if (_data)     delete _data->_streamData;
+        delete _data;
 
         throw;
     }
@@ -1118,8 +1114,8 @@ DeepTiledOutputFile::DeepTiledOutputFile
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
-        if (_data && _data->_streamData) delete _data->_streamData;
-        if (_data)       delete _data;
+        if (_data) delete _data->_streamData;
+        delete _data;
 
         REPLACE_EXC (e, "Cannot open image file "
                         "\"" << os.fileName() << "\". " << e);
@@ -1127,8 +1123,8 @@ DeepTiledOutputFile::DeepTiledOutputFile
     }
     catch (...)
     {
-        if (_data && _data->_streamData) delete _data->_streamData;
-        if (_data)       delete _data;
+        if (_data) delete _data->_streamData;
+        delete _data;
 
         throw;
     }
@@ -1154,7 +1150,7 @@ DeepTiledOutputFile::DeepTiledOutputFile(const OutputPartData* part)
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
-        if (_data) delete _data;
+        delete _data;
 
         REPLACE_EXC (e, "Cannot initialize output part "
                         "\"" << part->partNumber << "\". " << e);
@@ -1162,7 +1158,7 @@ DeepTiledOutputFile::DeepTiledOutputFile(const OutputPartData* part)
     }
     catch (...)
     {
-        if (_data) delete _data;
+        delete _data;
 
         throw;
     }
@@ -1218,8 +1214,7 @@ DeepTiledOutputFile::initialize (const Header &header)
 
     _data->format = defaultFormat (compressor);
 
-    if (compressor != 0)
-        delete compressor;
+    delete compressor;
 
     _data->tileOffsets = TileOffsets (_data->tileDesc.mode,
                                       _data->numXLevels,
@@ -1293,7 +1288,7 @@ DeepTiledOutputFile::~DeepTiledOutputFile ()
         // this file or by a parent multipart file.
         //
 
-        if (_data->partNumber == -1 && _data->_streamData)
+        if (_data->partNumber == -1)
             delete _data->_streamData;
 
         delete _data;

--- a/libraries/openexr/IlmImf/ImfDwaCompressor.cpp
+++ b/libraries/openexr/IlmImf/ImfDwaCompressor.cpp
@@ -1922,8 +1922,7 @@ DwaCompressor::compress
     if (outBufferSize > _outBufferSize) 
     {
         _outBufferSize = outBufferSize;
-        if (_outBuffer == 0)
-            delete[] _outBuffer;       
+        delete[] _outBuffer;       
         _outBuffer = new char[outBufferSize];
     }
 
@@ -2435,8 +2434,7 @@ DwaCompressor::uncompress
     if (_maxScanLineSize * numScanLines() > _outBufferSize) 
     {
         _outBufferSize = _maxScanLineSize * numScanLines();
-        if (_outBuffer != 0)
-            delete[] _outBuffer;
+        delete[] _outBuffer;
         _outBuffer = new char[_maxScanLineSize * numScanLines()];
     }
 
@@ -3023,8 +3021,7 @@ DwaCompressor::initializeBuffers (size_t &outBufferSize)
     if (maxLossyDctAcSize * numLossyDctChans > _packedAcBufferSize)
     {
         _packedAcBufferSize = maxLossyDctAcSize * numLossyDctChans;
-        if (_packedAcBuffer != 0) 
-            delete[] _packedAcBuffer;
+        delete[] _packedAcBuffer;
         _packedAcBuffer = new char[_packedAcBufferSize];
     }
 
@@ -3035,16 +3032,14 @@ DwaCompressor::initializeBuffers (size_t &outBufferSize)
     if (maxLossyDctDcSize * numLossyDctChans > _packedDcBufferSize)
     {
         _packedDcBufferSize = maxLossyDctDcSize * numLossyDctChans;
-        if (_packedDcBuffer != 0) 
-            delete[] _packedDcBuffer;
+        delete[] _packedDcBuffer;
         _packedDcBuffer     = new char[_packedDcBufferSize];
     }
 
     if (rleBufferSize > _rleBufferSize) 
     {
         _rleBufferSize = rleBufferSize;
-        if (_rleBuffer != 0) 
-            delete[] _rleBuffer;
+        delete[] _rleBuffer;
         _rleBuffer = new char[rleBufferSize];
     }
 
@@ -3104,8 +3099,7 @@ DwaCompressor::initializeBuffers (size_t &outBufferSize)
         if (planarUncBufferSize[i] > _planarUncBufferSize[i]) 
         {
             _planarUncBufferSize[i] = planarUncBufferSize[i];
-            if (_planarUncBuffer[i] != 0) 
-                delete[] _planarUncBuffer[i];
+            delete[] _planarUncBuffer[i];
             _planarUncBuffer[i] = new char[planarUncBufferSize[i]];
         }
     }

--- a/libraries/openexr/IlmImf/ImfHuf.cpp
+++ b/libraries/openexr/IlmImf/ImfHuf.cpp
@@ -705,11 +705,8 @@ hufFreeDecTable (HufDec *hdecod)	// io: Decoding table
 {
     for (int i = 0; i < HUF_DECSIZE; i++)
     {
-	if (hdecod[i].p)
-	{
 	    delete [] hdecod[i].p;
 	    hdecod[i].p = 0;
-	}
     }
 }
 

--- a/libraries/openexr/IlmImf/ImfInputFile.cpp
+++ b/libraries/openexr/IlmImf/ImfInputFile.cpp
@@ -138,18 +138,14 @@ InputFile::Data::Data (int numThreads):
 
 InputFile::Data::~Data ()
 {
-    if (tFile)
-        delete tFile;
-    if (sFile)
-        delete sFile;
-    if (dsFile)
-        delete dsFile;
-    if (compositor)
-        delete compositor;
+    delete tFile;
+    delete sFile;
+    delete dsFile;
+    delete compositor;
 
     deleteCachedBuffer();
 
-    if (multiPartBackwardSupport && multiPartFile)
+    if (multiPartBackwardSupport)
         delete multiPartFile;
 }
 
@@ -384,15 +380,15 @@ InputFile::InputFile (const char fileName[], int numThreads):
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
-        if (is)          delete is;
+        delete is;
          
-        if ( _data && !_data->multiPartBackwardSupport  && _data->_streamData)
+        if ( _data && !_data->multiPartBackwardSupport)
         {
             delete _data->_streamData;
             _data->_streamData=NULL;
         }
         
-        if (_data)       delete _data;
+        delete _data;
         _data=NULL;
 
         REPLACE_EXC (e, "Cannot read image file "
@@ -401,12 +397,12 @@ InputFile::InputFile (const char fileName[], int numThreads):
     }
     catch (...)
     {
-        if (is)          delete is;
-        if (_data && !_data->multiPartBackwardSupport && _data->_streamData)
+        delete is;
+        if (_data && !_data->multiPartBackwardSupport)
         {
             delete _data->_streamData;
         }
-        if (_data)       delete _data;
+        delete _data;
 
         throw;
     }
@@ -452,8 +448,8 @@ InputFile::InputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, int numThread
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
-        if (_data && !_data->multiPartBackwardSupport && _data->_streamData) delete _data->_streamData;
-        if (_data)       delete _data;
+        if (_data && !_data->multiPartBackwardSupport) delete _data->_streamData;
+        delete _data;
         _data=NULL; 
 
         REPLACE_EXC (e, "Cannot read image file "
@@ -462,8 +458,8 @@ InputFile::InputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, int numThread
     }
     catch (...)
     {
-        if (_data &&  !_data->multiPartBackwardSupport  && _data->_streamData) delete _data->_streamData;
-        if (_data)       delete _data;
+        if (_data &&  !_data->multiPartBackwardSupport) delete _data->_streamData;
+        delete _data;
         _data=NULL;
         throw;
     }
@@ -605,10 +601,10 @@ InputFile::~InputFile ()
 
     // unless this file was opened via the multipart API,
     // delete the streamData object too
-    if (_data->partNumber==-1 && _data->_streamData)
+    if (_data->partNumber==-1)
         delete _data->_streamData;
 
-    if (_data)  delete _data;
+    delete _data;
 }
 
 const char *

--- a/libraries/openexr/IlmImf/ImfOutputFile.cpp
+++ b/libraries/openexr/IlmImf/ImfOutputFile.cpp
@@ -678,8 +678,8 @@ OutputFile::OutputFile
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
-        if (_data && _data->_streamData) delete _data->_streamData;
-	if (_data)       delete _data;
+        if (_data) delete _data->_streamData;
+        delete _data;
 
 	REPLACE_EXC (e, "Cannot open image file "
 			"\"" << fileName << "\". " << e);
@@ -687,8 +687,8 @@ OutputFile::OutputFile
     }
     catch (...)
     {
-        if (_data && _data->_streamData) delete _data->_streamData;
-        if (_data)       delete _data;
+        if (_data) delete _data->_streamData;
+        delete _data;
 
         throw;
     }
@@ -722,8 +722,8 @@ OutputFile::OutputFile
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
-        if (_data && _data->_streamData) delete _data->_streamData;
-	if (_data)       delete _data;
+        if (_data) delete _data->_streamData;
+	delete _data;
 
 	REPLACE_EXC (e, "Cannot open image file "
 			"\"" << os.fileName() << "\". " << e);
@@ -731,8 +731,8 @@ OutputFile::OutputFile
     }
     catch (...)
     {
-        if (_data && _data->_streamData) delete _data->_streamData;
-        if (_data)       delete _data;
+        if (_data) delete _data->_streamData;
+        delete _data;
 
         throw;
     }
@@ -757,7 +757,7 @@ OutputFile::OutputFile(const OutputPartData* part) : _data(NULL)
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
-        if (_data) delete _data;
+        delete _data;
 
         REPLACE_EXC (e, "Cannot initialize output part "
                         "\"" << part->partNumber << "\". " << e);
@@ -765,7 +765,7 @@ OutputFile::OutputFile(const OutputPartData* part) : _data(NULL)
     }
     catch (...)
     {
-        if (_data) delete _data;
+        delete _data;
 
         throw;
     }
@@ -861,7 +861,7 @@ OutputFile::~OutputFile ()
         if (_data->_deleteStream && _data->_streamData)
             delete _data->_streamData->os;
 
-        if (_data->partNumber == -1 && _data->_streamData)
+        if (_data->partNumber == -1)
             delete _data->_streamData;
 
 	delete _data;

--- a/libraries/openexr/IlmImf/ImfTiledInputFile.cpp
+++ b/libraries/openexr/IlmImf/ImfTiledInputFile.cpp
@@ -736,8 +736,7 @@ TiledInputFile::TiledInputFile (const char fileName[], int numThreads):
             delete _data->_streamData;
         }
 
-        if (is != 0)
-            delete is;
+        delete is;
 
 	REPLACE_EXC (e, "Cannot open image file "
 			"\"" << fileName << "\". " << e);
@@ -756,8 +755,7 @@ TiledInputFile::TiledInputFile (const char fileName[], int numThreads):
             delete _data->_streamData;
         }
 
-        if (is != 0)
-            delete is;
+        delete is;
         throw;
     }
 }

--- a/libraries/openexr/IlmImf/ImfZip.cpp
+++ b/libraries/openexr/IlmImf/ImfZip.cpp
@@ -59,7 +59,7 @@ Imf::Zip::Zip(size_t maxScanLineSize, size_t numScanLines):
 
 Imf::Zip::~Zip()
 {
-    if (_tmpBuffer) delete[] _tmpBuffer;
+    delete[] _tmpBuffer;
 }
 
 size_t

--- a/libraries/zlib/contrib/iostream2/zstream_test.cpp
+++ b/libraries/zlib/contrib/iostream2/zstream_test.cpp
@@ -21,5 +21,6 @@ void main() {
     out << z << endl << y << endl << x << endl;
     out << 1.1234567890123456789 << endl;
 
-    delete[] x; delete[] y;
+    delete[] x;
+    delete[] y;
 }

--- a/source/backend/render/radiositytask.cpp
+++ b/source/backend/render/radiositytask.cpp
@@ -116,11 +116,8 @@ void RadiosityTask::Run()
         RadiosityBlockInfo* pBlockInfo = dynamic_cast<RadiosityBlockInfo*>(pInfo);
         if (!pBlockInfo)
         {
-            if (pInfo)
-            {
-                delete pInfo;
-                pInfo = nullptr;
-            }
+            delete pInfo;
+            pInfo = nullptr;
             pBlockInfo = new RadiosityBlockInfo();
         }
 

--- a/source/backend/scene/view.cpp
+++ b/source/backend/scene/view.cpp
@@ -119,8 +119,7 @@ ViewData::ViewData(shared_ptr<BackendSceneData> sd) :
 
 ViewData::~ViewData()
 {
-    if (rtrData != nullptr)
-        delete rtrData;
+    delete rtrData;
 }
 
 void ViewData::getBlockXY(const unsigned int nb, unsigned int &x, unsigned int &y)

--- a/source/base/image/dither.cpp
+++ b/source/base/image/dither.cpp
@@ -118,8 +118,7 @@ OrderedDither::Pattern::Pattern(std::initializer_list<std::initializer_list<int>
 
 OrderedDither::Pattern::~Pattern()
 {
-    if (maData != nullptr)
-        delete[] maData;
+    delete[] maData;
 }
 
 const ColourChannel& OrderedDither::Pattern::operator()(unsigned int x, unsigned int y) const
@@ -298,8 +297,7 @@ DiffusionDither::Filter::Filter(std::initializer_list<std::initializer_list<int>
 
 DiffusionDither::Filter::~Filter()
 {
-    if (maData != nullptr)
-        delete[] maData;
+    delete[] maData;
 }
 
 //------------------------------------------------------------------------------

--- a/source/base/pov_mem.cpp
+++ b/source/base/pov_mem.cpp
@@ -632,8 +632,7 @@ void mem_release_all()
         FREE(tmp);
     }
 
-    if (f != nullptr)
-        delete f;
+    delete f;
 
 //  if (totsize > 0)
 //      Debug_Info("\n%lu bytes reclaimed\n", totsize);

--- a/source/base/textstreambuffer.cpp
+++ b/source/base/textstreambuffer.cpp
@@ -75,8 +75,7 @@ TextStreamBuffer::~TextStreamBuffer()
     bsize = 0;
     wrap = 0;
     curline = 0;
-    if (buffer != nullptr)
-        delete[] buffer;
+    delete[] buffer;
     buffer = nullptr;
 }
 

--- a/source/core/bounding/boundingbox.cpp
+++ b/source/core/bounding/boundingbox.cpp
@@ -422,11 +422,8 @@ void Build_Bounding_Slabs(BBOX_TREE **Root, vector<ObjectPtr>& objects, unsigned
     Build_BBox_Tree(Root, numberOfFiniteObjects, Finite, numberOfInfiniteObjects, Infinite, maxfinitecount);
 
     // Get rid of the Finite and Infinite arrays and just use Root.
-    if (Finite != nullptr)
-        delete[] Finite;
-
-    if (Infinite != nullptr)
-        delete[] Infinite;
+    delete[] Finite;
+    delete[] Infinite;
 }
 
 bool Intersect_BBox_Tree(BBoxPriorityQueue& pqueue, const BBOX_TREE *Root, const Ray& ray, Intersection *Best_Intersection, TraceThreadData *Thread)

--- a/source/core/lighting/photons.cpp
+++ b/source/core/lighting/photons.cpp
@@ -1262,11 +1262,8 @@ SinCosOptimizations::SinCosOptimizations()
 
 SinCosOptimizations::~SinCosOptimizations()
 {
-    if (sinTheta)
-        delete[] sinTheta;
-
-    if (cosTheta)
-        delete[] cosTheta;
+    delete[] sinTheta;
+    delete[] cosTheta;
 }
 
 
@@ -1395,8 +1392,7 @@ PhotonMap::~PhotonMap()
     // free all non-nullptr blocks
     for (auto&& block : mBlockList)
     {
-        if (block != nullptr)
-            delete block;
+        delete block;
     }
 }
 
@@ -2610,11 +2606,8 @@ GatheredPhotons::GatheredPhotons(int maxGatherCount)
 
 GatheredPhotons::~GatheredPhotons()
 {
-    if (photonGatherList != nullptr)
-        delete[] photonGatherList;
-
-    if (photonDistances != nullptr)
-        delete[] photonDistances;
+    delete[] photonGatherList;
+    delete[] photonDistances;
 }
 
 

--- a/source/core/lighting/radiosity.cpp
+++ b/source/core/lighting/radiosity.cpp
@@ -1049,12 +1049,9 @@ RadiosityCache::~RadiosityCache()
         std::lock_guard<std::mutex> lock(fileMutex);
 #endif
         // finish up cache file
-        if (ot_fd != nullptr)
-        {
-            // close cache file
-            delete ot_fd;
-            ot_fd = nullptr;
-        }
+        // close cache file
+        delete ot_fd;
+        ot_fd = nullptr;
     }
 
     { // mutex scope

--- a/source/core/material/media.cpp
+++ b/source/core/material/media.cpp
@@ -111,8 +111,7 @@ Media::Media(const Media& source)
 
 Media::~Media()
 {
-    if (Sample_Threshold != nullptr)
-        delete[] Sample_Threshold;
+    delete[] Sample_Threshold;
 
     for (vector<PIGMENT*>::iterator i = Density.begin(); i != Density.end(); ++ i)
         Destroy_Pigment(*i);
@@ -146,8 +145,7 @@ Media& Media::operator=(const Media& source)
         AA_Threshold = source.AA_Threshold;
         AA_Level = source.AA_Level;
 
-        if (Sample_Threshold != nullptr)
-            delete[] Sample_Threshold;
+        delete[] Sample_Threshold;
         Sample_Threshold = nullptr;
 
         for (vector<PIGMENT*>::iterator i = Density.begin(); i != Density.end(); ++ i)
@@ -195,8 +193,7 @@ void Media::PostProcess()
     use_extinction = use_absorption || use_scattering;
 
     // Init sample threshold array.
-    if (Sample_Threshold != nullptr)
-        delete[] Sample_Threshold;
+    delete[] Sample_Threshold;
 
     // Create list of thresholds for confidence test.
     Sample_Threshold = new DBL[Max_Samples];

--- a/source/core/material/noise.cpp
+++ b/source/core/material/noise.cpp
@@ -280,16 +280,13 @@ static void InitTextureTable()
 
 void Free_Noise_Tables()
 {
-    if (sintab != nullptr)
-    {
-        delete[] sintab;
-        sintab = nullptr;
+    delete[] sintab;
+    sintab = nullptr;
 
 #ifdef DYNAMIC_HASHTABLE
-        delete[] hashTable;
-        hashTable = nullptr;
+    delete[] hashTable;
+    hashTable = nullptr;
 #endif
-    }
 }
 
 

--- a/source/core/material/normal.cpp
+++ b/source/core/material/normal.cpp
@@ -687,8 +687,7 @@ TNORMAL *Copy_Tnormal (TNORMAL *Old)
 
 void Destroy_Tnormal(TNORMAL *Tnormal)
 {
-    if (Tnormal != nullptr)
-        delete Tnormal;
+    delete Tnormal;
 }
 
 

--- a/source/core/material/pattern.cpp
+++ b/source/core/material/pattern.cpp
@@ -462,8 +462,7 @@ ColourFunctionPattern::~ColourFunctionPattern()
 {
     for (int iChannel = 0; iChannel < 5; ++iChannel)
     {
-        if (pFn[iChannel])
-            delete pFn[iChannel];
+        delete pFn[iChannel];
     }
 }
 
@@ -567,8 +566,7 @@ FunctionPattern::FunctionPattern(const FunctionPattern& obj) :
 
 FunctionPattern::~FunctionPattern()
 {
-    if (pFn)
-        delete pFn;
+    delete pFn;
 }
 
 
@@ -9196,18 +9194,15 @@ void Destroy_Density_File(DENSITY_FILE *Density_File)
 
                 if(Density_File->Data->Type == 4)
                 {
-                    if (Density_File->Data->Density32)
-                        delete[] Density_File->Data->Density32;
+                    delete[] Density_File->Data->Density32;
                 }
                 else if(Density_File->Data->Type == 2)
                 {
-                    if (Density_File->Data->Density16)
-                        delete[] Density_File->Data->Density16;
+                    delete[] Density_File->Data->Density16;
                 }
                 else if(Density_File->Data->Type == 1)
                 {
-                    if (Density_File->Data->Density8)
-                        delete[] Density_File->Data->Density8;
+                    delete[] Density_File->Data->Density8;
                 }
 
                 delete Density_File->Data;

--- a/source/core/material/pigment.cpp
+++ b/source/core/material/pigment.cpp
@@ -216,8 +216,7 @@ void Copy_Pigments (vector<PIGMENT*>& New, const vector<PIGMENT*>& Old)
 
 void Destroy_Pigment (PIGMENT *Pigment)
 {
-    if (Pigment != nullptr)
-        delete Pigment;
+    delete Pigment;
 }
 
 

--- a/source/core/material/texture.cpp
+++ b/source/core/material/texture.cpp
@@ -505,8 +505,7 @@ void Destroy_Textures(TEXTURE *Textures)
         // Theoretically these should only be non-`nullptr` for PLAIN_PATTERN, but let's clean them up either way.
         Destroy_Pigment(Layer->Pigment);
         Destroy_Tnormal(Layer->Tnormal);
-        if (Layer->Finish)
-            delete Layer->Finish;
+        delete Layer->Finish;
 
         // Theoretically these should only be non-empty for BITMAP_PATTERN, but let's clean them up either way.
         for(vector<TEXTURE*>::iterator i = Layer->Materials.begin(); i != Layer->Materials.end(); ++ i)

--- a/source/core/math/matrix.cpp
+++ b/source/core/math/matrix.cpp
@@ -1013,8 +1013,7 @@ TRANSFORM *Copy_Transform (const TRANSFORM*Old)
 
 void Destroy_Transform (TRANSFORM *Trans)
 {
-    if (Trans != nullptr)
-        delete Trans;
+    delete Trans;
 }
 
 

--- a/source/core/render/tracepixel.cpp
+++ b/source/core/render/tracepixel.cpp
@@ -221,14 +221,11 @@ TracePixel::TracePixel(std::shared_ptr<SceneData> sd, const Camera* cam, TraceTh
 
 TracePixel::~TracePixel()
 {
-    if (focalBlurData != nullptr)
-        delete focalBlurData;
+    delete focalBlurData;
     for (unsigned int i = 0; i < 3; ++i)
     {
-        if (mpCameraLocationFn[i] != nullptr)
-            delete mpCameraLocationFn[i];
-        if (mpCameraDirectionFn[i] != nullptr)
-            delete mpCameraDirectionFn[i];
+        delete mpCameraLocationFn[i];
+        delete mpCameraDirectionFn[i];
     }
 }
 
@@ -271,12 +268,10 @@ void TracePixel::SetupCamera(const Camera& cam)
             normalise = true;
             for (unsigned int i = 0; i < 3; ++i)
             {
-                if (mpCameraLocationFn[i] != nullptr)
-                    delete mpCameraLocationFn[i];
+                delete mpCameraLocationFn[i];
                 if (camera.Location_Fn[i] != nullptr)
                     mpCameraLocationFn[i] = new GenericScalarFunctionInstance(camera.Location_Fn[i], threadData);
-                if (mpCameraDirectionFn[i] != nullptr)
-                    delete mpCameraDirectionFn[i];
+                delete mpCameraDirectionFn[i];
                 if (camera.Direction_Fn[i] != nullptr)
                     mpCameraDirectionFn[i] = new GenericScalarFunctionInstance(camera.Direction_Fn[i], threadData);
             }
@@ -293,11 +288,8 @@ void TracePixel::SetupCamera(const Camera& cam)
         cameraDirection.normalize();
     }
 
-    if (focalBlurData != nullptr)
-    {
-        delete focalBlurData;
-        focalBlurData = nullptr;
-    }
+    delete focalBlurData;
+    focalBlurData = nullptr;
 
     // TODO: there is little point in calculating the grid separately for each thread.
     // since all threads in a given render must have identical grids, we should calculate

--- a/source/core/scene/atmosphere.cpp
+++ b/source/core/scene/atmosphere.cpp
@@ -63,7 +63,7 @@ Fog_Struct::Fog_Struct() :
 
 Fog_Struct::~Fog_Struct()
 {
-    if (Turb) delete Turb;
+    delete Turb;
 }
 
 /*****************************************************************************
@@ -195,8 +195,7 @@ FOG *Copy_Fog(const FOG *Old)
 
 void Destroy_Fog(FOG *Fog)
 {
-    if (Fog != nullptr)
-        delete Fog;
+    delete Fog;
 }
 
 
@@ -331,8 +330,7 @@ RAINBOW *Copy_Rainbow(const RAINBOW *Old)
 
 void Destroy_Rainbow(RAINBOW *Rainbow)
 {
-    if (Rainbow != nullptr)
-        delete Rainbow;
+    delete Rainbow;
 }
 
 
@@ -464,8 +462,7 @@ SKYSPHERE *Copy_Skysphere(const SKYSPHERE *Old)
 
 void Destroy_Skysphere(SKYSPHERE *Skysphere)
 {
-    if (Skysphere != nullptr)
-        delete Skysphere;
+    delete Skysphere;
 }
 
 Skysphere_Struct::~Skysphere_Struct()

--- a/source/core/scene/camera.cpp
+++ b/source/core/scene/camera.cpp
@@ -376,15 +376,13 @@ Camera& Camera::operator=(const Camera& src)
 
     for (unsigned int i = 0; i < 3; ++i)
     {
-        if (Location_Fn[i] != nullptr)
-            delete Location_Fn[i];
+        delete Location_Fn[i];
         if (src.Location_Fn[i] == nullptr)
             Location_Fn[i] = nullptr;
         else
             Location_Fn[i] = src.Location_Fn[i]->Clone();
 
-        if (Direction_Fn[i] != nullptr)
-            delete Direction_Fn[i];
+        delete Direction_Fn[i];
         if (src.Direction_Fn[i] == nullptr)
             Direction_Fn[i] = nullptr;
         else
@@ -444,10 +442,8 @@ Camera::~Camera()
     Meshes.clear();
     for (unsigned int i = 0; i < 3; ++i)
     {
-        if (Location_Fn[i] != nullptr)
-            delete Location_Fn[i];
-        if (Direction_Fn[i] != nullptr)
-            delete Direction_Fn[i];
+        delete Location_Fn[i];
+        delete Direction_Fn[i];
     }
 }
 

--- a/source/core/scene/object.h
+++ b/source/core/scene/object.h
@@ -193,7 +193,7 @@ class ObjectBase
 #endif
 
         /// Construct object from scratch.
-        ObjectBase(int t) :
+        explicit ObjectBase(int t) :
             Type(t),
             Texture(nullptr), Interior_Texture(nullptr), interior(), Trans(nullptr),
             Ph_Density(0), RadiosityImportance(0.0), RadiosityImportanceSet(false), Flags(0)

--- a/source/core/scene/scenedata.cpp
+++ b/source/core/scene/scenedata.cpp
@@ -132,8 +132,7 @@ SceneData::~SceneData()
     //       to handle cleanup of individual objects ?
     Destroy_Object(objects);
 
-    if (tree != nullptr)
-        delete tree;
+    delete tree;
 }
 
 }

--- a/source/core/shape/heightfield.cpp
+++ b/source/core/shape/heightfield.cpp
@@ -1340,10 +1340,7 @@ HField::~HField()
         {
             for (i = 0; i < Data->max_z+2; i++)
             {
-                if (Data->Map[i] != nullptr)
-                {
-                    delete[] Data->Map[i];
-                }
+                delete[] Data->Map[i];
             }
 
             delete[] Data->Map;

--- a/source/core/shape/polygon.cpp
+++ b/source/core/shape/polygon.cpp
@@ -599,8 +599,7 @@ Polygon::~Polygon()
     {
         if (--(Data->References) == 0)
         {
-            if (Data->Points != nullptr)
-                delete[] Data->Points;
+            delete[] Data->Points;
             delete Data;
         }
     }

--- a/source/core/shape/truetype.cpp
+++ b/source/core/shape/truetype.cpp
@@ -3104,9 +3104,7 @@ TrueTypeFont::TrueTypeFont(const UCS2String& fn, const std::shared_ptr<IStream>&
 TrueTypeFont::~TrueTypeFont()
 {
     file = nullptr;
-
-    if (info != nullptr)
-        delete info;
+    delete info;
 }
 
 CMAPSelector::CMAPSelector(USHORT pid, USHORT sid, CharsetID cs) :
@@ -3131,17 +3129,10 @@ CMAP4Info::CMAP4Info() :
 
 CMAP4Info::~CMAP4Info()
 {
-    if (endCount != nullptr)
-        delete[] endCount;
-
-    if (startCount != nullptr)
-        delete[] startCount;
-
-    if (idDelta != nullptr)
-        delete[] idDelta;
-
-    if (idRangeOffset != nullptr)
-        delete[] idRangeOffset;
+    delete[] endCount;
+    delete[] startCount;
+    delete[] idDelta;
+    delete[] idRangeOffset;
 }
 
 TrueTypeInfo::TrueTypeInfo() :
@@ -3160,13 +3151,11 @@ TrueTypeInfo::TrueTypeInfo() :
 
 TrueTypeInfo::~TrueTypeInfo()
 {
-    if (loca_table != nullptr)
-        delete[] loca_table;
+    delete[] loca_table;
 
     for (GlyphPtrMap::iterator iGlyph = glyphsByIndex.begin(); iGlyph != glyphsByIndex.end(); ++iGlyph)
     {
-        if ((*iGlyph).second->contours != nullptr)
-            delete[] (*iGlyph).second->contours;
+        delete[] (*iGlyph).second->contours;
         delete (*iGlyph).second;
     }
 
@@ -3174,19 +3163,16 @@ TrueTypeInfo::~TrueTypeInfo()
     {
         for (int i = 0; i < kerning_tables.nTables; i++)
         {
-            if (kerning_tables.tables[i].kern_pairs != nullptr)
-                delete[] kerning_tables.tables[i].kern_pairs;
+            delete[] kerning_tables.tables[i].kern_pairs;
         }
 
         delete[] kerning_tables.tables;
     }
 
-    if (hmtx_table != nullptr)
-        delete[] hmtx_table;
+    delete[] hmtx_table;
 
     for (std::vector<CMAPInfo*>::iterator i = cmapInfo.begin(); i != cmapInfo.end(); ++i)
-        if (*i != nullptr)
-            delete *i;
+        delete *i;
 }
 
 }

--- a/source/core/support/imageutil.cpp
+++ b/source/core/support/imageutil.cpp
@@ -1397,12 +1397,10 @@ ImageData::~ImageData()
 {
 #ifdef POV_VIDCAP_IMPL
     // beta-test feature
-    if (VidCap != nullptr)
-        delete VidCap;
+    delete VidCap;
 #endif
 
-    if (data != nullptr)
-        delete data;
+    delete data;
 }
 
 }

--- a/source/frontend/processoptions.cpp
+++ b/source/frontend/processoptions.cpp
@@ -116,8 +116,7 @@ int ProcessOptions::ParseFile(const char *filespec, POVMSObjectPtr obj)
             if(token == '[')
             {
                 // free old section name, if any
-                if (currentsection != nullptr)
-                    delete[] currentsection;
+                delete[] currentsection;
 
                 // read until the section name end marker
                 currentsection = Parse_INI_String(file, ']');
@@ -210,8 +209,7 @@ int ProcessOptions::ParseFile(const char *filespec, POVMSObjectPtr obj)
                     if(err == kFalseErr)
                         err = ProcessUnknownString(plainstring, obj);
 
-                    if (plainstring != nullptr)
-                        delete[] plainstring;
+                    delete[] plainstring;
                 }
             }
         }
@@ -237,18 +235,12 @@ int ProcessOptions::ParseFile(const char *filespec, POVMSObjectPtr obj)
             }
         }
 
-        if (currentsection != nullptr)
-            delete[] currentsection;
+        delete[] currentsection;
     }
 
-    if (filename != nullptr)
-        delete[] filename;
-
-    if (sectionname != nullptr)
-        delete[] sectionname;
-
-    if (file != nullptr)
-        delete file;
+    delete[] filename;
+    delete[] sectionname;
+    delete file;
 
     return err;
 }
@@ -332,8 +324,7 @@ int ProcessOptions::ParseString(const char *commandline, POVMSObjectPtr obj, boo
             if(err == kFalseErr)
                 err = ProcessUnknownString(plainstring, obj);
 
-            if (plainstring != nullptr)
-                delete[] plainstring;
+            delete[] plainstring;
         }
     }
 
@@ -992,10 +983,8 @@ int ProcessOptions::Parse_INI_Switch(ITextStream *file, int token, POVMSObjectPt
         }
     }
 
-    if (key != nullptr)
-        delete[] key;
-    if (value != nullptr)
-        delete[] value;
+    delete[] key;
+    delete[] value;
 
     return err;
 }
@@ -1301,10 +1290,8 @@ int ProcessOptions::Parse_CL_Switch(const char *&commandline, int token, POVMSOb
         }
     }
 
-    if (key != nullptr)
-        delete[] key;
-    if (value != nullptr)
-        delete[] value;
+    delete[] key;
+    delete[] value;
 
     return err;
 }

--- a/source/parser/parser.cpp
+++ b/source/parser/parser.cpp
@@ -1292,11 +1292,8 @@ void Parser::Parse_User_Defined_Camera (Camera& Cam)
             {
                 for(unsigned int i = 0; i < 3; ++i)
                 {
-                    if (Cam.Location_Fn[i] != nullptr)
-                    {
-                        delete Cam.Location_Fn[i];
-                        Cam.Location_Fn[i] = nullptr;
-                    }
+                    delete Cam.Location_Fn[i];
+                    Cam.Location_Fn[i] = nullptr;
                 }
                 Parse_Vector(Cam.Location);
             }
@@ -1313,11 +1310,8 @@ void Parser::Parse_User_Defined_Camera (Camera& Cam)
             {
                 for(unsigned int i = 0; i < 3; ++i)
                 {
-                    if (Cam.Direction_Fn[i] != nullptr)
-                    {
-                        delete Cam.Direction_Fn[i];
-                        Cam.Direction_Fn[i] = nullptr;
-                    }
+                    delete Cam.Direction_Fn[i];
+                    Cam.Direction_Fn[i] = nullptr;
                 }
                 Parse_Vector(Cam.Direction);
             }
@@ -6509,8 +6503,7 @@ void Parser::Parse_Default ()
         CASE (FINISH_TOKEN)
             Local_Finish = Copy_Finish((Default_Texture->Finish));
             Parse_Finish (&Local_Finish);
-            if (Default_Texture->Finish)
-                delete Default_Texture->Finish;
+            delete Default_Texture->Finish;
             Default_Texture->Finish = Local_Finish;
         END_CASE
 

--- a/source/parser/parser_materials.cpp
+++ b/source/parser/parser_materials.cpp
@@ -2246,8 +2246,7 @@ void Parser::Parse_Finish (FINISH **Finish_Ptr)
 
     if (AllowToken(FINISH_ID_TOKEN))
     {
-        if (*Finish_Ptr)
-            delete *Finish_Ptr;
+        delete *Finish_Ptr;
         *Finish_Ptr = Copy_Finish(CurrentTokenDataPtr<FINISH*>());
     }
 
@@ -2606,8 +2605,7 @@ TEXTURE *Parser::Parse_Texture ()
 
             CASE (FINISH_ID_TOKEN)
                 Warn_State(FINISH_TOKEN);
-                if (Texture->Finish)
-                    delete Texture->Finish;
+                delete Texture->Finish;
                 Texture->Finish = Copy_Finish (CurrentTokenDataPtr<FINISH*>());
                 Modified_Pnf = true;
             END_CASE
@@ -2726,8 +2724,7 @@ TEXTURE *Parser::Parse_Texture ()
                 UNGET
                 Destroy_Pigment(Texture->Pigment);
                 Destroy_Tnormal(Texture->Tnormal);
-                if (Texture->Finish)
-                    delete Texture->Finish;
+                delete Texture->Finish;
                 Texture->Pigment = nullptr;
                 Texture->Tnormal = nullptr;
                 Texture->Finish  = nullptr;
@@ -2778,8 +2775,7 @@ TEXTURE *Parser::Parse_Tiles()
     Texture = Create_Texture ();
     Destroy_Pigment(Texture->Pigment);
     Destroy_Tnormal(Texture->Tnormal);
-    if (Texture->Finish)
-        delete Texture->Finish;
+    delete Texture->Finish;
     Texture->Pigment = nullptr;
     Texture->Tnormal = nullptr;
     Texture->Finish  = nullptr;
@@ -2862,8 +2858,7 @@ TEXTURE *Parser::Parse_Material_Map()
     Texture = Create_Texture ();
     Destroy_Pigment(Texture->Pigment);
     Destroy_Tnormal(Texture->Tnormal);
-    if (Texture->Finish)
-        delete Texture->Finish;
+    delete Texture->Finish;
     Texture->Pigment = nullptr;
     Texture->Tnormal = nullptr;
     Texture->Finish  = nullptr;
@@ -3003,8 +2998,7 @@ TEXTURE *Parser::Parse_Vers1_Texture ()
                 END_CASE
 
                 CASE (FINISH_ID_TOKEN)
-                    if (Texture->Finish)
-                        delete Texture->Finish;
+                    delete Texture->Finish;
                     Texture->Finish = Copy_Finish (CurrentTokenDataPtr<FINISH*>());
                 END_CASE
 

--- a/source/parser/parser_tokenizer.cpp
+++ b/source/parser/parser_tokenizer.cpp
@@ -2142,8 +2142,7 @@ Parser::Macro::~Macro()
         POV_FREE(parameters[i].name);
     }
 
-    if (Cache != nullptr)
-        delete[] Cache;
+    delete[] Cache;
 }
 
 Parser::POV_ARRAY *Parser::Parse_Array_Declare (void)

--- a/source/povms/povmscpp.cpp
+++ b/source/povms/povmscpp.cpp
@@ -1412,22 +1412,16 @@ void POVMS_Object::Read(InputStream& stream, bool continued, bool headeronly)
                 throw POV_EXCEPTION_CODE(pov_base::kCannotHandleDataErr);
         }
 
-        if (objectstream != nullptr)
-            delete[] objectstream;
+        delete[] objectstream;
         objectstream = nullptr;
 
-        if (compressedstream != nullptr)
-            delete[] compressedstream;
+        delete[] compressedstream;
         compressedstream = nullptr;
     }
     catch(...)
     {
-        if (objectstream != nullptr)
-            delete[] objectstream;
-
-        if (compressedstream != nullptr)
-            delete[] compressedstream;
-
+        delete[] objectstream;
+        delete[] compressedstream;
         throw;
     }
 }
@@ -1504,22 +1498,16 @@ void POVMS_Object::Write(OutputStream& stream, bool append, bool compress)
                 throw POV_EXCEPTION_CODE(pov_base::kFileDataErr);
         }
 
-        if (objectstream != nullptr)
-            delete[] objectstream;
+        delete[] objectstream;
         objectstream = nullptr;
 
-        if (compressedstream != nullptr)
-            delete[] compressedstream;
+        delete[] compressedstream;
         compressedstream = nullptr;
     }
     catch(...)
     {
-        if (objectstream != nullptr)
-            delete[] objectstream;
-
-        if (compressedstream != nullptr)
-            delete[] compressedstream;
-
+        delete[] objectstream;
+        delete[] compressedstream;
         throw;
     }
 }
@@ -1822,10 +1810,8 @@ void POVMS_MessageReceiver::RemoveNode(HandlerNode *nodeptr)
         if(receivers == nodeptr)
             receivers = nodeptr->next;
 
-        if (nodeptr->handleroo != nullptr)
-            delete nodeptr->handleroo;
-        if (nodeptr->handler != nullptr)
-            delete nodeptr->handler;
+        delete nodeptr->handleroo;
+        delete nodeptr->handler;
 
         delete nodeptr;
     }

--- a/windows/cmedit/editorinterface.cpp
+++ b/windows/cmedit/editorinterface.cpp
@@ -2161,8 +2161,7 @@ void ShowHint (HMENU hMenu, DWORD id)
   if (index == count)
     return ;
 
-  if (pCurrentHintBitmap != NULL)
-    delete pCurrentHintBitmap;
+  delete pCurrentHintBitmap;
 
   CStdStringW fn(filename);
   pCurrentHintBitmap = new Bitmap(fn, true);


### PR DESCRIPTION
The check for `nullptr` before calling `delete` or `delete[]` is not necessary, because these operators check for nullptr already itself, as required by the C++ standard.

POV-Ray's code has a lot of (newer?) code that don't check, and some (older?) code that does these unecessary checks.

This pull request removes the unnecessary checks but keep them when there are more to do, e.g. joining threads or calling other functions before the object is deleted.